### PR TITLE
Rounds architecture, line markers, facts sidecar, and C++ to C+ translation

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -47,11 +47,17 @@ jobs:
     - name: Rename Binary
       run: mv ${{ github.workspace }}/build/tri-pp ${{ github.workspace }}/tri-pp-${{ matrix.os }}
 
+    - name: Checksum
+      if: startsWith(github.ref, 'refs/tags/')
+      run: cd ${{ github.workspace }} && sha256sum tri-pp-${{ matrix.os }} > tri-pp-${{ matrix.os }}.sha256
+
     - name: Create Release
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v2
       with:
-        files: ${{ github.workspace }}/tri-pp-${{ matrix.os }}
+        files: |
+          ${{ github.workspace }}/tri-pp-${{ matrix.os }}
+          ${{ github.workspace }}/tri-pp-${{ matrix.os }}.sha256
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(tricera-preprocessors)
-set(PROJECT_VERSION "0.2.0")
+set(PROJECT_VERSION "0.3.0")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/TriceraConfig.hpp.in"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/TriceraConfig.hpp")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(tri-pp_SOURCES
   lib/TypedefRemover.cpp
   lib/UnusedDeclCommenter.cpp
   lib/TypeCanoniser.cpp
+  lib/CXXToCPlusTranslator.cpp
   lib/ForLoopStmtExtractor.cpp
   lib/CharRewriter.cpp
   lib/Utilites.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ set(TRICERA_TOOLS
 
 set(tri-pp_SOURCES
   TriceraPreprocessorMain.cpp
+  lib/TrackedRewriter.cpp
+  lib/LineMarkerEmitter.cpp
+  lib/FactsCollector.cpp
   lib/TriceraPreprocessor.cpp
   lib/UsedFunctionAndTypeCollector.cpp
   lib/TypedefRemover.cpp

--- a/TriceraPreprocessorMain.cpp
+++ b/TriceraPreprocessorMain.cpp
@@ -212,13 +212,15 @@ newFactsActionFactory(ProgramFacts &facts) {
 }
 
 // One transformer per round, so the transformers cannot conflict. The
-// order matters: unused declarations go first, the later rounds never see
-// them; the for-loop and loop-guard rounds leave copies that later rounds
-// rewrite as ordinary code; types are canonised before the typedefs are
-// removed (TypeCanonise also names anonymous tags, so its output parses
-// on its own).
+// order matters: C++ is lowered to C first; unused declarations go next,
+// the later rounds never see them; the for-loop and loop-guard rounds
+// leave copies that later rounds rewrite as ordinary code; types are
+// canonised before the typedefs are removed (TypeCanonise also names
+// anonymous tags, so its output parses on its own). CXX_TO_CPLUS is a
+// no-op on C inputs, so its round is free there (the parse is reused).
 static std::vector<Round> computeRounds() {
   std::vector<Round> rounds;
+  rounds.push_back(Round{Stage::CXX_TO_CPLUS});
   if (makeCallsUnique) {
     rounds.push_back(Round{Stage::MAKE_CALLS_UNIQUE});
   } else if (determinize) {

--- a/TriceraPreprocessorMain.cpp
+++ b/TriceraPreprocessorMain.cpp
@@ -255,6 +255,13 @@ int main(int argc, const char **argv) {
   signal(SIGILL, immediate_exit_handler);
   signal(SIGFPE, immediate_exit_handler);
 
+  // -v must work without positional arguments
+  for (int i = 1; i < argc; ++i)
+    if (strcmp(argv[i], "-v") == 0) {
+      outs() << "tricera-preprocessor v" TRI_PP_VERSION << "\n";
+      return 0;
+    }
+
   try {
     auto OptionsParser = clang::tooling::CommonOptionsParser::create(argc, argv, TPCategory);
     if (!OptionsParser) {
@@ -267,11 +274,6 @@ int main(int argc, const char **argv) {
       return 0;
     }
     CommonOptionsParser &Parser = *OptionsParser;
-    if (dispVer)
-    {
-      outs() << "tricera-preprocessor v" TRI_PP_VERSION << "\n";
-      return 0;
-    }
 
     // suppress stderr output
     int fd = -1, n = -1;

--- a/TriceraPreprocessorMain.cpp
+++ b/TriceraPreprocessorMain.cpp
@@ -1,5 +1,7 @@
 #include "TriceraPreprocessor.hpp"
 #include "TriceraConfig.hpp"
+#include "LineMarkerEmitter.hpp"
+#include "FactsCollector.hpp"
 
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Tooling/CommonOptionsParser.h"
@@ -7,7 +9,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Error.h"
 #include <string.h>
 #include <iostream>
@@ -45,72 +49,196 @@ cl::opt<bool> makeCallsUnique("make-calls-unique",
 cl::opt<bool> noDeclSlice("no-decl-slice",
                      cl::desc("Disable slicing: keep all declarations (don't comment out unused code)"),
                      cl::cat(TPCategory));
+cl::opt<bool> lineMarkers("line-markers",
+                     cl::desc("Emit GNU linemarkers (# <line> \"<file>\") mapping "
+                              "rewritten output lines back to original input lines"),
+                     cl::cat(TPCategory));
+cl::opt<std::string> factsFilename("facts",
+                     cl::desc("Write facts about the produced program (YAML) "
+                              "to the given path"),
+                     cl::value_desc("facts file path"),
+                     cl::cat(TPCategory), cl::init(""));
 
 //===----------------------------------------------------------------------===//
 // PluginASTAction
 //===----------------------------------------------------------------------===//
 class TriCeraPreprocessAction : public clang::ASTFrontendAction {
 public:
-  TriCeraPreprocessAction(PreprocessOutput &out) :
-    preprocessOutput(out) {}
+  TriCeraPreprocessAction(PreprocessOutput &out, StagedState &state) :
+    preprocessOutput(out), state(state) {}
 
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  StringRef file) override {
     rewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-    return std::make_unique<MainConsumer>(rewriter, preprocessOutput);
+    state.tracker = EditTracker(); // this parse's edits only
+    trackedRewriter = std::make_unique<TrackedRewriter>(rewriter,
+                                                        state.tracker);
+    return std::make_unique<MainConsumer>(*trackedRewriter, preprocessOutput,
+                                          state);
+  }
+
+  // single-line, length-capped rendering of edit text for diagnostics
+  static std::string printableText(const std::string &text) {
+    std::string s;
+    for (size_t i = 0; i < text.size() && s.size() < 60; ++i) {
+      if (text[i] == '\n') s += "\\n";
+      else if (text[i] == '\t') s += "\\t";
+      else s += text[i];
+    }
+    if (s.size() >= 60) s += "...";
+    return s;
+  }
+
+  void describeEdit(const TrackedEdit &e, raw_ostream &os) {
+    SourceManager &sm = rewriter.getSourceMgr();
+    FileID fid = sm.getMainFileID();
+    unsigned line = sm.getLineNumber(fid, e.offset);
+    unsigned col = sm.getColumnNumber(fid, e.offset);
+    os << "  [" << e.transformer << "] ";
+    if (e.isInsertion())
+      os << "insertion at line " << line << ":" << col
+         << " (offset " << e.offset << ")";
+    else
+      os << "replacement at line " << line << ":" << col
+         << " (offsets " << e.offset << "-" << (e.offset + e.length) << ")";
+    os << ": \"" << printableText(e.text) << "\"\n";
   }
 
   void EndSourceFileAction() override {
     SourceManager &sm = rewriter.getSourceMgr();
-    std::unique_ptr<raw_pwrite_stream> outFile;
 
-    if (outputFilename.empty()) {
-      outFile = std::make_unique<raw_fd_ostream>(STDOUT_FILENO, false);
-    } else {
-      std::error_code error_code;
-      outFile = std::make_unique<raw_fd_ostream>(outputFilename.c_str(), error_code, sys::fs::OF_None);
-      if (error_code) {
-        llvm::errs() << "Error opening output file '" << outputFilename << "': " << error_code.message() << "\n";
+    // order-dependent rewrites are a bug; report them, produce no output
+    std::vector<std::pair<TrackedEdit, TrackedEdit> > conflicts =
+        state.tracker.nonCommutingPairs();
+    if (!conflicts.empty()) {
+      llvm::errs() << "[tricera-preprocessor] error: " << conflicts.size()
+                   << " conflicting rewrite pair(s) detected, output not written\n";
+      for (size_t i = 0; i < conflicts.size(); ++i) {
+        llvm::errs() << "conflict " << (i + 1) << ":\n";
+        describeEdit(conflicts[i].first, llvm::errs());
+        describeEdit(conflicts[i].second, llvm::errs());
+      }
+      preprocessOutput.hasRewriteConflict = true;
+      return;
+    }
+
+    StringRef original = sm.getBufferData(sm.getMainFileID());
+    state.lastOriginal = original.str();
+    const RewriteBuffer *Buf = rewriter.getRewriteBufferFor(sm.getMainFileID());
+    if (Buf && lineMarkers) {
+      // markers of an earlier round (or of cpp) are consumed via the
+      // presumed locations and re-emitted fresh
+      std::string rewritten(Buf->begin(), Buf->end());
+      std::string error;
+      if (!emitLineMarkers(original, rewritten, state.tracker, sm,
+                           state.currentText, error)) {
+        llvm::errs() << "[tricera-preprocessor] error: " << error << "\n";
         preprocessOutput.hasErrorOccurred = true;
         return;
       }
-    }
-
-    const RewriteBuffer *Buf = rewriter.getRewriteBufferFor(sm.getMainFileID());
-    if (Buf) {
-      std::string finalCode(Buf->begin(), Buf->end());
-      *outFile << finalCode;
+    } else if (Buf) {
+      state.currentText.assign(Buf->begin(), Buf->end());
     } else {
-      rewriter.getEditBuffer(sm.getMainFileID()).write(*outFile);
+      // an unrewritten input passes through verbatim
+      state.currentText = original.str();
     }
+    state.producedOutput = true;
   }
 
   PreprocessOutput &preprocessOutput;
 private:
   clang::Rewriter rewriter;
+  StagedState &state;
+  std::unique_ptr<TrackedRewriter> trackedRewriter;
   StringRef inFile;
 };
 
 std::unique_ptr<FrontendActionFactory>
-newTPFrontendActionFactory(PreprocessOutput &out) {
+newTPFrontendActionFactory(PreprocessOutput &out, StagedState &state) {
   class TPFrontendActionFactory : public FrontendActionFactory {
   public:
-    TPFrontendActionFactory(PreprocessOutput &out) :
-      out(out) {}
+    TPFrontendActionFactory(PreprocessOutput &out, StagedState &state) :
+      out(out), state(state) {}
     std::unique_ptr<FrontendAction> create() override {
-      return std::make_unique<TriCeraPreprocessAction>(out);
+      return std::make_unique<TriCeraPreprocessAction>(out, state);
     }
   private:
     PreprocessOutput &out;
+    StagedState &state;
   };
 
   return std::unique_ptr<FrontendActionFactory>(
-                                                new TPFrontendActionFactory(out));
+                              new TPFrontendActionFactory(out, state));
+}
+
+// collects the facts from a parse of the final text; needed when the last
+// round rewrote something (the facts must describe the output)
+class FactsCollectAction : public clang::ASTFrontendAction {
+public:
+  FactsCollectAction(ProgramFacts &facts) : facts(facts) {}
+
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef file) override {
+    class FactsConsumer : public ASTConsumer {
+    public:
+      FactsConsumer(ProgramFacts &facts) : facts(facts) {}
+      void HandleTranslationUnit(clang::ASTContext &Ctx) override {
+        collectFacts(Ctx, facts);
+      }
+    private:
+      ProgramFacts &facts;
+    };
+    return std::make_unique<FactsConsumer>(facts);
+  }
+
+private:
+  ProgramFacts &facts;
+};
+
+std::unique_ptr<FrontendActionFactory>
+newFactsActionFactory(ProgramFacts &facts) {
+  class FactsActionFactory : public FrontendActionFactory {
+  public:
+    FactsActionFactory(ProgramFacts &facts) : facts(facts) {}
+    std::unique_ptr<FrontendAction> create() override {
+      return std::make_unique<FactsCollectAction>(facts);
+    }
+  private:
+    ProgramFacts &facts;
+  };
+
+  return std::unique_ptr<FrontendActionFactory>(
+                              new FactsActionFactory(facts));
+}
+
+// One transformer per round, so the transformers cannot conflict. The
+// order matters: unused declarations go first, the later rounds never see
+// them; the for-loop and loop-guard rounds leave copies that later rounds
+// rewrite as ordinary code; types are canonised before the typedefs are
+// removed (TypeCanonise also names anonymous tags, so its output parses
+// on its own).
+static std::vector<Round> computeRounds() {
+  std::vector<Round> rounds;
+  if (makeCallsUnique) {
+    rounds.push_back(Round{Stage::MAKE_CALLS_UNIQUE});
+  } else if (determinize) {
+    rounds.push_back(Round{Stage::DETERMINIZE});
+  } else {
+    rounds.push_back(Round{Stage::UNUSED_DECL_REMOVE});
+    rounds.push_back(Round{Stage::FOR_LOOP_EXTRACT});
+    rounds.push_back(Round{Stage::NONDET_LOOP_GUARD_REWRITE});
+    rounds.push_back(Round{Stage::CHAR_REWRITE});
+    rounds.push_back(Round{Stage::TYPE_CANONISE});
+    rounds.push_back(Round{Stage::TYPEDEF_REMOVE});
+    rounds.push_back(Round{Stage::CONTRACT_ANNOTATE});
+  }
+  return rounds;
 }
 
 constexpr int EXIT_CODE_SUCCESS = 0;
 constexpr int EXIT_CODE_SOFT_FAIL = 2; // For parsing errors, file errors, etc.
 constexpr int EXIT_CODE_CMD_LINE_ERROR = 3;
+constexpr int EXIT_CODE_REWRITE_CONFLICT = 4; // conflicting transformer edits
 
 /// @brief Immediately terminate the process using an exit code that reflects
 ///        the signal number.
@@ -142,8 +270,6 @@ int main(int argc, const char **argv) {
       outs() << "tricera-preprocessor v" TRI_PP_VERSION << "\n";
       return 0;
     }
-    ClangTool tool(Parser.getCompilations(),
-                                  Parser.getSourcePathList());
 
     // suppress stderr output
     int fd = -1, n = -1;
@@ -154,15 +280,86 @@ int main(int argc, const char **argv) {
       close(n);
     }
 
-    PreprocessOutput preprocessOutput;
-    int tool_result = tool.run(newTPFrontendActionFactory(preprocessOutput).get());
+    PreprocessOutput preprocessOutput = {};
+    StagedState state;
+    state.rounds = computeRounds();
+
+    SmallString<256> absInputPath(
+        StringRef(Parser.getSourcePathList()[0]));
+    sys::fs::make_absolute(absInputPath);
+
+    // each parse executes as many rounds as it can, the next parse reads
+    // the produced text from memory
+    bool parseFailed = false;
+    while (true) {
+      ClangTool tool(Parser.getCompilations(),
+                                    Parser.getSourcePathList());
+      if (state.nextRound > 0)
+        tool.mapVirtualFile(absInputPath, state.currentText);
+      state.producedOutput = false;
+      state.executedThrough = state.nextRound - 1; // "no round executed"
+      if (tool.run(
+              newTPFrontendActionFactory(preprocessOutput, state).get()) != 0)
+        parseFailed = true; // tolerated; TriCera accepts more than clang does
+      if (preprocessOutput.hasRewriteConflict ||
+          preprocessOutput.hasErrorOccurred || !state.producedOutput)
+        break;
+      if (state.executedThrough + 1 <= state.nextRound) {
+        // the parse did not execute its round (e.g. a fatal error skipped
+        // the consumer); stop instead of spinning
+        parseFailed = true;
+        break;
+      }
+      if (state.executedThrough + 1 >= state.rounds.size())
+        break;
+      state.nextRound = state.executedThrough + 1;
+    }
+
+    // when the last round rewrote nothing, the facts of the last parse
+    // already describe the output; otherwise collect them again
+    if (!factsFilename.empty() && state.producedOutput &&
+        state.currentText != state.lastOriginal) {
+      ClangTool factsTool(Parser.getCompilations(),
+                                        Parser.getSourcePathList());
+      factsTool.mapVirtualFile(absInputPath, state.currentText);
+      factsTool.run(newFactsActionFactory(state.facts).get());
+    }
 
     if (quiet) {
       dup2(fd, 2); // restore stderr output
       close(fd);
     }
 
-    if (tool_result != 0 || preprocessOutput.hasErrorOccurred) {
+    if (preprocessOutput.hasRewriteConflict) {
+      _exit(EXIT_CODE_REWRITE_CONFLICT);
+    }
+
+    if (state.producedOutput) {
+      std::unique_ptr<raw_pwrite_stream> outFile;
+      if (outputFilename.empty()) {
+        outFile = std::make_unique<raw_fd_ostream>(STDOUT_FILENO, false);
+      } else {
+        std::error_code error_code;
+        outFile = std::make_unique<raw_fd_ostream>(outputFilename.c_str(), error_code, sys::fs::OF_None);
+        if (error_code) {
+          llvm::errs() << "Error opening output file '" << outputFilename << "': " << error_code.message() << "\n";
+          _exit(EXIT_CODE_SOFT_FAIL);
+        }
+      }
+      *outFile << state.currentText;
+
+      if (!factsFilename.empty()) {
+        std::string factsError;
+        if (!writeFacts(factsFilename, state.facts, state.currentText,
+                        factsError)) {
+          llvm::errs() << "[tricera-preprocessor] error: " << factsError << "\n";
+          preprocessOutput.hasErrorOccurred = true;
+        }
+      }
+    }
+
+    if (parseFailed || preprocessOutput.hasErrorOccurred ||
+        !state.producedOutput) {
       _exit(EXIT_CODE_SOFT_FAIL);
     }
 

--- a/include/CXXToCPlusTranslator.hpp
+++ b/include/CXXToCPlusTranslator.hpp
@@ -1,0 +1,61 @@
+// Translates C++ to C+, the C-like subset TriCera parses: monomorphises
+// template instantiations, replaces their uses with mangled names, makes
+// implicit member accesses explicit (this->), qualifies non-virtual member
+// calls and casts throw operands. The mangled name / original name pairs
+// are recorded in the facts sidecar for back-translation.
+
+#pragma once
+
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "TrackedRewriter.hpp"
+#include "FactsCollector.hpp"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+class CXXToCPlusTranslator : public clang::RecursiveASTVisitor<CXXToCPlusTranslator> {
+public:
+  explicit CXXToCPlusTranslator(clang::ASTContext &Context,
+                            TrackedRewriter &Rewriter,
+                            std::vector<MangledName> &MangledNamesOut)
+      : Context(Context), Rewriter(Rewriter),
+        MangledNamesOut(MangledNamesOut) {}
+
+  bool VisitClassTemplateDecl(clang::ClassTemplateDecl *D);
+  bool VisitClassTemplateSpecializationDecl(clang::ClassTemplateSpecializationDecl *D);
+  bool VisitFunctionTemplateDecl(clang::FunctionTemplateDecl *D);
+  bool VisitFunctionDecl(clang::FunctionDecl *D);
+  bool VisitCallExpr(clang::CallExpr *E);
+  bool VisitTypeLoc(clang::TypeLoc TL);
+  bool VisitFieldDecl(clang::FieldDecl *D);
+  bool VisitMemberExpr(clang::MemberExpr *ME);
+  bool VisitCXXThrowExpr(clang::CXXThrowExpr *E);
+  bool VisitCXXMemberCallExpr(clang::CXXMemberCallExpr *CE);
+
+  bool shouldVisitTemplateInstantiations() const;
+  bool shouldVisitImplicitCode() const;
+
+private:
+  std::string mangleTemplateName(const clang::ClassTemplateSpecializationDecl *D);
+  std::string mangleFunctionName(const clang::FunctionDecl *D);
+  // records the pair once, keyed by mangled name
+  void recordMangledName(const std::string &mangled, const std::string &original);
+  // true if `loc` is inside a template definition we remove; such text and
+  // everything in it is gone, so it must not be rewritten
+  bool insideRemovedTemplate(clang::SourceLocation loc) const;
+
+  clang::ASTContext &Context;
+  TrackedRewriter &Rewriter;
+  std::vector<MangledName> &MangledNamesOut;
+  // source ranges of the template definitions removed by this pass
+  std::vector<clang::SourceRange> RemovedTemplates;
+  std::map<const clang::ClassTemplateSpecializationDecl*, std::string> MangledNames;
+  std::map<const clang::FunctionDecl*, std::string> FunctionMangledNames;
+  std::set<const clang::Decl*> VisitedDecls;
+  std::set<const clang::MemberExpr*> VisitedMemberExprs;
+};

--- a/include/CharRewriter.hpp
+++ b/include/CharRewriter.hpp
@@ -10,13 +10,14 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 #include "Utilities.hpp"
 
 class CharRewriterMatcher : 
   public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  CharRewriterMatcher(clang::Rewriter &r, 
+  CharRewriterMatcher(TrackedRewriter &r, 
                        UsedFunAndTypeCollector &usedFunsAndTypes) 
                        : rewriter(r), usedFunsAndTypes(usedFunsAndTypes) {}
   // this callback executes on a match
@@ -26,13 +27,13 @@ public:
   void onEndOfTranslationUnit() override{};
 
   private:
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   UsedFunAndTypeCollector &usedFunsAndTypes;
 };
 
 class CharRewriterASTConsumer : public clang::ASTConsumer {
 public:
-  CharRewriterASTConsumer(clang::Rewriter &r, 
+  CharRewriterASTConsumer(TrackedRewriter &r, 
                            UsedFunAndTypeCollector &usedFunsAndTypes);
   void HandleTranslationUnit(clang::ASTContext &Ctx) override {
     finder.matchAST(Ctx);
@@ -40,11 +41,11 @@ public:
 private:
   clang::ast_matchers::MatchFinder finder;
   std::unique_ptr<CharRewriterMatcher> handler;
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
 };
 
 class CharRewriter {
 public:
-  CharRewriter(clang::Rewriter &r, clang::ASTContext &Ctx, 
+  CharRewriter(TrackedRewriter &r, clang::ASTContext &Ctx, 
                UsedFunAndTypeCollector &usedFunsAndTypes);
 };

--- a/include/Determinizer.hpp
+++ b/include/Determinizer.hpp
@@ -2,6 +2,7 @@
 
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "TrackedRewriter.hpp"
 #include "ExecutionCountAnalyzer.hpp"
 #include <string>
 #include <vector>
@@ -16,15 +17,19 @@ struct UnboundedInputInfo {
 
 class Determinizer {
 public:
-    Determinizer(clang::Rewriter &R, clang::ASTContext &Ctx,
+    Determinizer(TrackedRewriter &R, clang::ASTContext &Ctx,
                  const ExecutionCountAnalyzer &Analyzer);
+
+    // inputs that were added to the program by this pass
+    std::vector<std::string> addedInputVariables() const;
+    std::vector<std::string> addedInputArrays() const;
 
 private:
     friend class DeterminizerVisitor;
 
     void run();
 
-    clang::Rewriter &TheRewriter;
+    TrackedRewriter &TheRewriter;
     clang::ASTContext &Context;
     const ExecutionCountAnalyzer &ExecAnalyzer;
 

--- a/include/FactsCollector.hpp
+++ b/include/FactsCollector.hpp
@@ -1,0 +1,29 @@
+// A pass to create a YAML file with facts about the final preprocessed program.
+
+#pragma once
+
+#include "clang/AST/ASTContext.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+struct ProgramFacts {
+  // names of the allocation functions the program references
+  std::set<std::string> allocationFunctions;
+  // some declaration has an array type
+  bool usesArrays = false;
+  // some declaration has an array type of unknown bound
+  bool usesUnboundedArrays = false;
+  // input variables and input arrays added by the determinizer
+  std::vector<std::string> inputVariables;
+  std::vector<std::string> inputArrays;
+};
+
+// collects the facts above from the AST
+void collectFacts(clang::ASTContext &Ctx, ProgramFacts &facts);
+
+// writes the facts file. `finalText` is the produced output
+bool writeFacts(llvm::StringRef path, const ProgramFacts &facts,
+                llvm::StringRef finalText, std::string &error);

--- a/include/FactsCollector.hpp
+++ b/include/FactsCollector.hpp
@@ -16,6 +16,9 @@ struct ProgramFacts {
   bool usesArrays = false;
   // some declaration has an array type of unknown bound
   bool usesUnboundedArrays = false;
+  // the program contains a throw expression / a try-catch block
+  bool usesThrow = false;
+  bool usesTryCatch = false;
   // input variables and input arrays added by the determinizer
   std::vector<std::string> inputVariables;
   std::vector<std::string> inputArrays;

--- a/include/FactsCollector.hpp
+++ b/include/FactsCollector.hpp
@@ -9,6 +9,13 @@
 #include <string>
 #include <vector>
 
+// a synthesized name and the original name it stands for
+// e.g. "Pair_int_" for "Pair<int>"
+struct MangledName {
+  std::string mangled;
+  std::string original;
+};
+
 struct ProgramFacts {
   // names of the allocation functions the program references
   std::set<std::string> allocationFunctions;
@@ -22,6 +29,8 @@ struct ProgramFacts {
   // input variables and input arrays added by the determinizer
   std::vector<std::string> inputVariables;
   std::vector<std::string> inputArrays;
+  // mangled names from C++ template instantiation
+  std::vector<MangledName> mangledNames;
 };
 
 // collects the facts above from the AST

--- a/include/ForLoopStmtExtractor.hpp
+++ b/include/ForLoopStmtExtractor.hpp
@@ -10,13 +10,14 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 #include "Utilities.hpp"
 
 class ForLoopStmtExtractorMatcher : 
   public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  ForLoopStmtExtractorMatcher(clang::Rewriter &r, 
+  ForLoopStmtExtractorMatcher(TrackedRewriter &r, 
                        UsedFunAndTypeCollector &usedFunsAndTypes) 
                        : rewriter(r), usedFunsAndTypes(usedFunsAndTypes) {}
   // this callback executes on a match
@@ -26,25 +27,25 @@ public:
   void onEndOfTranslationUnit() override{};
 
   private:
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   UsedFunAndTypeCollector &usedFunsAndTypes;
 };
 
 class ForLoopStmtExtractorASTConsumer : public clang::ASTConsumer {
 public:
-  ForLoopStmtExtractorASTConsumer(clang::Rewriter &r, 
+  ForLoopStmtExtractorASTConsumer(TrackedRewriter &r, 
                            UsedFunAndTypeCollector &usedFunsAndTypes);
   void HandleTranslationUnit(clang::ASTContext &Ctx) override {
     finder.matchAST(Ctx);
   }
 private:
   clang::ast_matchers::MatchFinder finder;
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   std::unique_ptr<ForLoopStmtExtractorMatcher> handler;
 };
 
 class ForLoopStmtExtractor {
 public:
-  ForLoopStmtExtractor(clang::Rewriter &r, clang::ASTContext &Ctx, 
+  ForLoopStmtExtractor(TrackedRewriter &r, clang::ASTContext &Ctx, 
                        UsedFunAndTypeCollector &usedFunsAndTypes);
 };

--- a/include/LineMarkerEmitter.hpp
+++ b/include/LineMarkerEmitter.hpp
@@ -1,0 +1,22 @@
+// Emission of GNU linemarkers ("# <line> \"<file>\"") at the output, 
+// mapping back to the original.
+//
+// The mapping is derived from EditTracker's net edits, in original
+// main-file coordinates. Marker values take into account existing ones
+// for example possibly from cpp.
+
+#pragma once
+
+#include "TrackedRewriter.hpp"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
+// `original`: unrewritten main-file buffer, 
+// `rewritten`: RewriteBuffer's result. 
+// The tracked edits are first checked to reproduce `rewritten` exactly; 
+// on mismatch the function returns false and sets `error`.
+bool emitLineMarkers(llvm::StringRef original, llvm::StringRef rewritten,
+                     const EditTracker &tracker, clang::SourceManager &SM,
+                     std::string &result, std::string &error);

--- a/include/NondetLoopGuardRewriter.hpp
+++ b/include/NondetLoopGuardRewriter.hpp
@@ -2,6 +2,7 @@
 
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "TrackedRewriter.hpp"
 #include <vector>
 
 namespace clang {
@@ -12,14 +13,14 @@ namespace clang {
 class NondetLoopGuardRewriter :
   public clang::RecursiveASTVisitor<NondetLoopGuardRewriter> {
 public:
-    explicit NondetLoopGuardRewriter(clang::Rewriter &R, clang::ASTContext &Ctx);
+    explicit NondetLoopGuardRewriter(TrackedRewriter &R, clang::ASTContext &Ctx);
 
     bool VisitWhileStmt(clang::WhileStmt *S);
 
 private:
     void rewriteWhileStmt(clang::WhileStmt *S);
 
-    clang::Rewriter &rewriter;
+    TrackedRewriter &rewriter;
     clang::ASTContext &context;
     int tempLoopIdxCounter;
     std::vector<clang::WhileStmt *> loopsToRewrite;

--- a/include/TrackedRewriter.hpp
+++ b/include/TrackedRewriter.hpp
@@ -1,0 +1,150 @@
+// Edit tracking (to not silently fail on conflicts).
+//
+// Transformers edit through a TrackedRewriter: each call is forwarded
+// unchanged to the clang::Rewriter and recorded in an EditTracker, in
+// coordinates of the unmodified main-file buffer. The log gives the
+// conflict check (nonCommutingPairs) and the line marker mapping.
+//
+// The idea is similar to clang::tooling::Replacements, which was not used
+// to make implementing a future rewrite algebra easier.
+
+#pragma once
+
+#include "clang/Basic/SourceManager.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+struct TrackedEdit {
+  enum class Kind {
+    INSERTION,   // length == 0
+    REPLACEMENT,
+    BLANK // whitespace replacement, identical geometry, newlines kept
+  };
+
+  std::string transformer;
+  Kind kind;
+  // start offset in the original main-file buffer
+  unsigned offset;
+  // number of original characters replaced, 0 for insertions
+  unsigned length;
+  // new text (after indentNewLines expansion)
+  std::string text;
+  // same-offset composition order for insertions
+  bool insertAfter;
+  // application order, 0-based
+  unsigned seq;
+  // original line the first line of `text` comes from (function clones),
+  // 0 if none better than the line at `offset`
+  unsigned originLine;
+
+  bool isInsertion() const { return kind == Kind::INSERTION; }
+  bool isBlank() const { return kind == Kind::BLANK; }
+};
+
+// original range [offset, offset+length) becomes `text`
+struct NetEdit {
+  unsigned offset;
+  unsigned length;
+  std::string text;
+  // see TrackedEdit::originLine; 0 if none was given
+  unsigned originLine;
+};
+
+class EditTracker {
+public:
+  void record(llvm::StringRef transformer, TrackedEdit::Kind kind,
+              unsigned offset, unsigned length, llvm::StringRef text,
+              bool insertAfter, unsigned originLine = 0) {
+    TrackedEdit e;
+    e.transformer = transformer.str();
+    e.kind = kind;
+    e.offset = offset;
+    e.length = length;
+    e.text = text.str();
+    e.insertAfter = insertAfter;
+    e.seq = (unsigned)edits.size();
+    e.originLine = originLine;
+    edits.push_back(std::move(e));
+  }
+
+  const std::vector<TrackedEdit> &getEdits() const { return edits; }
+  size_t size() const { return edits.size(); }
+  bool empty() const { return edits.empty(); }
+
+  // the pairs of edits whose result depends on application order. within
+  // one transformer some edits commute: identical replacements,
+  // several insertions at one offset, overlapping blanks
+  // (their union), insertions at the edges of a replaced range.
+  std::vector<std::pair<TrackedEdit, TrackedEdit> > nonCommutingPairs() const;
+
+  // the log as a sorted list of pairwise disjoint edits with the same
+  // effect; only meaningful when nonCommutingPairs() is empty. `original`
+  // is the unmodified main-file buffer.
+  std::vector<NetEdit> disjointEdits(llvm::StringRef original) const;
+
+  // applies disjointEdits() to the original buffer; used to check the log
+  // reproduces the RewriteBuffer output
+  std::string apply(llvm::StringRef original) const;
+
+private:
+  // the log with repeated identical replacements applied once
+  std::vector<TrackedEdit> editsWithoutRepeats() const;
+
+  std::vector<TrackedEdit> edits;
+};
+
+// records every main-file edit under the active transformer name.
+class TrackedRewriter {
+public:
+  TrackedRewriter(clang::Rewriter &rewriter, EditTracker &tracker)
+      : rewriter(rewriter), tracker(tracker), activeTransformer("<unknown>") {}
+
+  void setActiveTransformer(llvm::StringRef name) {
+    activeTransformer = name.str();
+  }
+
+  clang::SourceManager &getSourceMgr() const { return rewriter.getSourceMgr(); }
+  const clang::LangOptions &getLangOpts() const { return rewriter.getLangOpts(); }
+
+  // originLine: see TrackedEdit
+  bool InsertText(clang::SourceLocation Loc, llvm::StringRef Str,
+                  bool InsertAfter = true, bool indentNewLines = false,
+                  unsigned originLine = 0);
+
+  bool InsertTextAfter(clang::SourceLocation Loc, llvm::StringRef Str) {
+    return InsertText(Loc, Str);
+  }
+
+  bool InsertTextBefore(clang::SourceLocation Loc, llvm::StringRef Str) {
+    return InsertText(Loc, Str, false);
+  }
+
+  bool InsertTextAfterToken(clang::SourceLocation Loc, llvm::StringRef Str);
+
+  bool ReplaceText(clang::SourceRange range, llvm::StringRef NewStr);
+
+  // replaces the token range with whitespace of identical geometry
+  // keeps newlines
+  bool BlankText(clang::SourceRange range);
+
+  // same, for the character range [B, E)
+  bool BlankChars(clang::SourceLocation B, clang::SourceLocation E);
+
+  std::string getRewrittenText(clang::SourceRange Range) const {
+    return rewriter.getRewrittenText(Range);
+  }
+
+private:
+  // records an edit if Loc is in the main file
+  void recordAt(clang::SourceLocation Loc, unsigned extraOffset,
+                TrackedEdit::Kind kind, unsigned length, llvm::StringRef text,
+                bool insertAfter, unsigned originLine = 0);
+
+  clang::Rewriter &rewriter;
+  EditTracker &tracker;
+  std::string activeTransformer;
+};

--- a/include/TrackedRewriter.hpp
+++ b/include/TrackedRewriter.hpp
@@ -119,11 +119,13 @@ public:
     return InsertText(Loc, Str);
   }
 
-  bool InsertTextBefore(clang::SourceLocation Loc, llvm::StringRef Str) {
-    return InsertText(Loc, Str, false);
+  bool InsertTextBefore(clang::SourceLocation Loc, llvm::StringRef Str,
+                        unsigned originLine = 0) {
+    return InsertText(Loc, Str, false, false, originLine);
   }
 
-  bool InsertTextAfterToken(clang::SourceLocation Loc, llvm::StringRef Str);
+  bool InsertTextAfterToken(clang::SourceLocation Loc, llvm::StringRef Str,
+                            unsigned originLine = 0);
 
   bool ReplaceText(clang::SourceRange range, llvm::StringRef NewStr);
 

--- a/include/TriCeraPreprocessorMain.hpp
+++ b/include/TriCeraPreprocessorMain.hpp
@@ -10,6 +10,8 @@ typedef struct PreprocessOutput {
   int isUnsupported; // boolean
   // 1 if error occurred while processing the file
   int hasErrorOccurred; // boolean
+  // 1 if conflicting (order-dependent) rewrites were detected
+  int hasRewriteConflict; // boolean
   // a char buffer to return a string, currently not used for anything
   char* outputBuffer;  
   //...

--- a/include/TriceraConfig.hpp
+++ b/include/TriceraConfig.hpp
@@ -1,4 +1,4 @@
 #ifndef TRICERA_CONFIG_HPP
 #define TRICERA_CONFIG_HPP
-#define TRI_PP_VERSION "0.2.0"
+#define TRI_PP_VERSION "0.3.0"
 #endif

--- a/include/TriceraPreprocessor.hpp
+++ b/include/TriceraPreprocessor.hpp
@@ -20,6 +20,7 @@ class UsedFunAndTypeCollector;
 // one transformer stage; each round runs on a fresh parse of the previous
 // round's text, so rounds cannot conflict
 enum class Stage {
+  CXX_TO_CPLUS,
   TYPE_CANONISE,
   TYPEDEF_REMOVE,
   CHAR_REWRITE,

--- a/include/TriceraPreprocessor.hpp
+++ b/include/TriceraPreprocessor.hpp
@@ -8,17 +8,58 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
+#include "FactsCollector.hpp"
 #include "TriCeraPreprocessorMain.hpp"
+
+#include <string>
+#include <vector>
+
+class UsedFunAndTypeCollector;
+
+// one transformer stage; each round runs on a fresh parse of the previous
+// round's text, so rounds cannot conflict
+enum class Stage {
+  TYPE_CANONISE,
+  TYPEDEF_REMOVE,
+  CHAR_REWRITE,
+  FOR_LOOP_EXTRACT,
+  NONDET_LOOP_GUARD_REWRITE,
+  CONTRACT_ANNOTATE,
+  UNUSED_DECL_REMOVE,
+  MAKE_CALLS_UNIQUE,
+  DETERMINIZE
+};
+
+typedef std::vector<Stage> Round;
+
+// state carried across the parses. a parse executes rounds from nextRound
+// until one rewrites something; the next round then needs a fresh parse.
+struct StagedState {
+  std::vector<Round> rounds;
+  size_t nextRound = 0;        // first round of the coming parse
+  size_t executedThrough = 0;  // last round index the parse executed
+  std::string currentText;     // the text the parse produced
+  bool producedOutput = false; // the parse reached the end of its action
+  ProgramFacts facts;          // facts collected by the most recent parse
+  EditTracker tracker;         // edits made by the most recent parse
+  std::string lastOriginal;    // the text the most recent parse was given
+};
 
 class MainConsumer : public clang::ASTConsumer {
 public:
-  MainConsumer(clang::Rewriter &rewriter,
-               PreprocessOutput &out) : 
-               rewriter(rewriter), preprocessOutput(out) {}
+  MainConsumer(TrackedRewriter &rewriter,
+               PreprocessOutput &out,
+               StagedState &state) :
+               rewriter(rewriter), preprocessOutput(out), state(state) {}
   void HandleTranslationUnit(clang::ASTContext& Ctx) override;
   ~MainConsumer() override;
 
 private:
-  clang::Rewriter &rewriter;
+  void runStage(Stage stage, clang::ASTContext &Ctx,
+                UsedFunAndTypeCollector &usedFunsAndTypes, bool hadError);
+
+  TrackedRewriter &rewriter;
   PreprocessOutput &preprocessOutput;
+  StagedState &state;
 };

--- a/include/TypeCanoniser.hpp
+++ b/include/TypeCanoniser.hpp
@@ -14,12 +14,13 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 
 class TypeCanoniserMatcher : 
   public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  TypeCanoniserMatcher(clang::Rewriter &r, 
+  TypeCanoniserMatcher(TrackedRewriter &r, 
                   UsedFunAndTypeCollector &usedFunsAndTypes)
                   : rewriter(r), usedFunsAndTypes(usedFunsAndTypes) {}
   // this callback executes on a match
@@ -29,26 +30,26 @@ public:
   void onEndOfTranslationUnit() override{};
 
 private:
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   llvm::SmallSet<clang::SourceLocation, 32> editedLocations;
   UsedFunAndTypeCollector &usedFunsAndTypes;
 };
 
 class TypeCanoniserASTConsumer : public clang::ASTConsumer {
 public:
-  TypeCanoniserASTConsumer(clang::Rewriter &r, 
+  TypeCanoniserASTConsumer(TrackedRewriter &r, 
                            UsedFunAndTypeCollector &usedFunsAndTypes);
   void HandleTranslationUnit(clang::ASTContext &Ctx) override;
 private:
   clang::ast_matchers::MatchFinder finder;
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   std::unique_ptr<TypeCanoniserMatcher> handler;
 };
 
 // collects all seen functions and types on construction
 class TypeCanoniser {
   public:
-  TypeCanoniser(clang::Rewriter &r, clang::ASTContext &Ctx, 
+  TypeCanoniser(TrackedRewriter &r, clang::ASTContext &Ctx, 
                 UsedFunAndTypeCollector &usedFunsAndTypes) {
     TypeCanoniserASTConsumer c(r, usedFunsAndTypes);
     c.HandleTranslationUnit(Ctx);

--- a/include/TypedefRemover.hpp
+++ b/include/TypedefRemover.hpp
@@ -8,12 +8,13 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 
 class TypedefMatcher : 
   public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  TypedefMatcher(clang::Rewriter &rewriter, 
+  TypedefMatcher(TrackedRewriter &rewriter, 
     UsedFunAndTypeCollector &usedFunsAndTypes) : rewriter(rewriter), 
                                           usedFunsAndTypes(usedFunsAndTypes) {}
   // this callback executes on a match
@@ -23,28 +24,28 @@ public:
   void onEndOfTranslationUnit() override{};
 
   private:
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   llvm::SmallSet<clang::SourceLocation, 32> EditedLocations;
   UsedFunAndTypeCollector &usedFunsAndTypes;
 };
 
 class TypedefRemoverASTConsumer : public clang::ASTConsumer {
 public:
-  TypedefRemoverASTConsumer(clang::Rewriter &rewriter,
+  TypedefRemoverASTConsumer(TrackedRewriter &rewriter,
                             UsedFunAndTypeCollector &usedFunsAndTypes);
   void HandleTranslationUnit(clang::ASTContext &Ctx) override {
     finder.matchAST(Ctx);
   }
 private:
   clang::ast_matchers::MatchFinder finder;
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   TypedefMatcher handler;
 };
 
 // collects all seen functions and types on construction
 class TypedefRemover {
   public:
-  TypedefRemover(clang::Rewriter &rewriter, clang::ASTContext &Ctx, 
+  TypedefRemover(TrackedRewriter &rewriter, clang::ASTContext &Ctx, 
                  UsedFunAndTypeCollector &usedFunsAndTypes) {
     TypedefRemoverASTConsumer c(rewriter, usedFunsAndTypes);
     c.HandleTranslationUnit(Ctx);

--- a/include/UniqueCallSiteTransformer.hpp
+++ b/include/UniqueCallSiteTransformer.hpp
@@ -3,6 +3,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "llvm/ADT/DenseMap.h"
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 
 #include <map>
@@ -10,7 +11,7 @@
 
 class UniqueCallTransformer {
 public:
-  UniqueCallTransformer(clang::Rewriter &R, clang::ASTContext &Ctx,
+  UniqueCallTransformer(TrackedRewriter &R, clang::ASTContext &Ctx,
                                     const UsedFunAndTypeCollector &U);
 
   void transform();
@@ -34,7 +35,7 @@ private:
   // name of the cloned function.
   std::string getOrCreateClone(const clang::FunctionDecl *FD);
 
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   clang::ASTContext &Ctx;
   const UsedFunAndTypeCollector &usedFunsAndTypes;
 

--- a/include/UnusedDeclCommenter.hpp
+++ b/include/UnusedDeclCommenter.hpp
@@ -10,13 +10,14 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
+#include "TrackedRewriter.hpp"
 #include "UsedFunctionAndTypeCollector.hpp"
 #include "Utilities.hpp"
 
 class UnusedDeclCommenterMatcher : 
   public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  UnusedDeclCommenterMatcher(clang::Rewriter &r, 
+  UnusedDeclCommenterMatcher(TrackedRewriter &r, 
                        UsedFunAndTypeCollector &usedFunsAndTypes) 
                        : rewriter(r), usedFunsAndTypes(usedFunsAndTypes) {}
   // this callback executes on a match
@@ -26,7 +27,7 @@ public:
   void onEndOfTranslationUnit() override{};
 
   private:
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   //llvm::SmallSet<const clang::Decl*, 32> commentedDecls;
   // or
   //llvm::SmallSet<const clang::Decl*, 32> commentedLines;
@@ -35,20 +36,20 @@ public:
 
 class UnusedDeclCommenterASTConsumer : public clang::ASTConsumer {
 public:
-  UnusedDeclCommenterASTConsumer(clang::Rewriter &r, 
+  UnusedDeclCommenterASTConsumer(TrackedRewriter &r, 
                            UsedFunAndTypeCollector &usedFunsAndTypes);
   void HandleTranslationUnit(clang::ASTContext &Ctx) override {
     finder.matchAST(Ctx);
   }
 private:
   clang::ast_matchers::MatchFinder finder;
-  clang::Rewriter &rewriter;
+  TrackedRewriter &rewriter;
   std::unique_ptr<UnusedDeclCommenterMatcher> handler;
 };
 
 // collects all seen functions and types on construction
 class UnusedDeclCommenter {
 public:
-  UnusedDeclCommenter(clang::Rewriter &r, clang::ASTContext &Ctx, 
+  UnusedDeclCommenter(TrackedRewriter &r, clang::ASTContext &Ctx, 
                       UsedFunAndTypeCollector &usedFunsAndTypes);
 };

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -1,25 +1,17 @@
 #pragma once
 
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "TrackedRewriter.hpp"
 #include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 
-// comments out the passed declaration using double slash comments
-// todo: if there is another declaration in the same line, move it
-bool doubleSlashCommentOutDeclaration (const clang::Decl* declaration, 
-                                       clang::ASTContext &ctx,
-                                       clang::Rewriter& rewriter);
-
-// comments out the passed range with C-style comments (i.e. /*...*/)
-// does not check if the range already contains C-style comments, which
-// might lead to errors if they exist
-// insertBeforeBegin and insertBefore end determine where the comments will
-// be inserted w.r.t. the source beginning and end locations
-void wrapWithCComment (clang::SourceRange sourceRange,
-                       clang::Rewriter& rewriter,
-                       bool insertBeforeBegin = true,
-                       bool insertBeforeEnd = true);        
+// removes the declaration by blanking it out, together with a trailing
+// semicolon and a preceding stand-alone __extension__ line.
+// returns false if the declaration is not in the main file.
+bool blankOutDeclaration (const clang::Decl* declaration,
+                          clang::ASTContext &ctx,
+                          TrackedRewriter& rewriter);
 
 // This visitor is used to recursively traverse types
 // and extract the underlying type free of pointers and qualifiers

--- a/lib/CXXToCPlusTranslator.cpp
+++ b/lib/CXXToCPlusTranslator.cpp
@@ -1,0 +1,456 @@
+#include "CXXToCPlusTranslator.hpp"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/SourceManager.h"
+#include <regex>
+#include <algorithm>
+#include <cctype>
+
+using namespace clang;
+using namespace clang::ast_matchers;
+
+// flattens a printed name to an identifier: template arguments and
+// qualifiers become underscores, other non-alphanumerics are dropped,
+// trailing underscore runs collapse
+static std::string flattenName(std::string name) {
+  std::replace(name.begin(), name.end(), '<', '_');
+  std::replace(name.begin(), name.end(), '>', '_');
+  std::replace(name.begin(), name.end(), ',', '_');
+  std::replace(name.begin(), name.end(), ' ', '_');
+  std::replace(name.begin(), name.end(), ':', '_');
+  name.erase(std::remove_if(name.begin(), name.end(), [](char c) {
+    return !std::isalnum((unsigned char)c) && c != '_';
+  }), name.end());
+  while (name.length() > 1 && name[name.length()-1] == '_' &&
+         name[name.length()-2] == '_')
+    name.pop_back();
+  return name;
+}
+
+// quotes regex metacharacters, so names like operator() stay literal
+static std::string escapeForRegex(const std::string &name) {
+  std::string out;
+  for (size_t i = 0; i < name.size(); ++i) {
+    if (!std::isalnum((unsigned char)name[i]) && name[i] != '_')
+      out += '\\';
+    out += name[i];
+  }
+  return out;
+}
+
+// the original line a synthetic insertion is attributed to: the line of
+// `loc` in the main file, or 0
+static unsigned originLineOf(SourceManager &SM, SourceLocation loc) {
+  if (loc.isInvalid())
+    return 0;
+  std::pair<FileID, unsigned> d = SM.getDecomposedLoc(loc);
+  if (d.first != SM.getMainFileID())
+    return 0;
+  return SM.getLineNumber(d.first, d.second);
+}
+
+void CXXToCPlusTranslator::recordMangledName(const std::string &mangled,
+                                         const std::string &original) {
+  for (size_t i = 0; i < MangledNamesOut.size(); ++i)
+    if (MangledNamesOut[i].mangled == mangled)
+      return;
+  MangledName m;
+  m.mangled = mangled;
+  m.original = original;
+  MangledNamesOut.push_back(m);
+}
+
+bool CXXToCPlusTranslator::insideRemovedTemplate(SourceLocation loc) const {
+  if (loc.isInvalid())
+    return false;
+  SourceManager &SM = Context.getSourceManager();
+  unsigned off = SM.getDecomposedLoc(loc).second;
+  FileID fid = SM.getDecomposedLoc(loc).first;
+  for (size_t i = 0; i < RemovedTemplates.size(); ++i) {
+    SourceRange r = RemovedTemplates[i];
+    if (SM.getDecomposedLoc(r.getBegin()).first != fid)
+      continue;
+    if (SM.getDecomposedLoc(r.getBegin()).second <= off &&
+        off <= SM.getDecomposedLoc(r.getEnd()).second)
+      return true;
+  }
+  return false;
+}
+
+bool CXXToCPlusTranslator::VisitClassTemplateDecl(ClassTemplateDecl *D) {
+  if (Context.getSourceManager().isInSystemHeader(D->getLocation()))
+    return true;
+
+  // remove the template definition; the instantiations replace it
+  SourceRange Range = D->getSourceRange();
+  if (Range.isValid()) {
+    RemovedTemplates.push_back(Range);
+    Rewriter.BlankText(Range);
+  }
+
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitFunctionTemplateDecl(FunctionTemplateDecl *D) {
+  if (Context.getSourceManager().isInSystemHeader(D->getLocation()))
+    return true;
+
+  // remove the function template definition; the instantiations replace it
+  SourceRange Range = D->getSourceRange();
+  if (Range.isValid()) {
+    RemovedTemplates.push_back(Range);
+    Rewriter.BlankText(Range);
+  }
+
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitFunctionDecl(FunctionDecl *D) {
+  SourceManager &SM = Context.getSourceManager();
+  if (SM.isInSystemHeader(D->getLocation()))
+    return true;
+
+  if (D->isTemplateInstantiation()) {
+    if (llvm::isa<clang::CXXMethodDecl>(D))
+      return true;
+    // inject a concrete version with a mangled name
+    if (D->isThisDeclarationADefinition()) {
+      std::string Mangled = mangleFunctionName(D);
+
+      std::string OriginalName;
+      llvm::raw_string_ostream OrigOS(OriginalName);
+      D->getNameForDiagnostic(OrigOS, Context.getPrintingPolicy(), true);
+      OrigOS.flush();
+      recordMangledName(Mangled, OriginalName);
+
+      std::string InstCode;
+      llvm::raw_string_ostream OS(InstCode);
+      PrintingPolicy Policy = Context.getPrintingPolicy();
+      Policy.TerseOutput = false;
+
+      D->print(OS, Policy);
+      OS << "\n";
+      OS.flush();
+
+      std::regex TemplatePrefixRegex("^\\s*template\\s*<[^>]*>\\s*");
+      InstCode = std::regex_replace(InstCode, TemplatePrefixRegex, "");
+
+      std::regex SigNameRegex(
+          "\\b" + escapeForRegex(D->getNameAsString()) + "\\s*(<[^>]*>)?");
+      InstCode = std::regex_replace(InstCode, SigNameRegex, Mangled);
+
+      SourceLocation EndLoc;
+      if (FunctionTemplateDecl *TD = D->getDescribedFunctionTemplate()) {
+        EndLoc = TD->getSourceRange().getEnd();
+      } else if (D->getMemberSpecializationInfo()) {
+        EndLoc = D->getSourceRange().getEnd();
+      } else {
+        EndLoc = D->getEndLoc();
+      }
+
+      if (EndLoc.isValid())
+        Rewriter.InsertTextAfterToken(EndLoc, "\n\n" + InstCode,
+                                      originLineOf(SM, D->getBeginLoc()));
+    }
+  }
+
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitCallExpr(CallExpr *E) {
+  if (Context.getSourceManager().isInSystemHeader(E->getBeginLoc()))
+    return true;
+  if (insideRemovedTemplate(E->getBeginLoc()))
+    return true;
+
+  if (FunctionDecl *FD = E->getDirectCallee()) {
+    if (FD->isTemplateInstantiation()) {
+      if (llvm::isa<clang::CXXMethodDecl>(FD))
+        return true;
+      std::string Mangled = mangleFunctionName(FD);
+      SourceRange Range;
+      if (auto *DRE = dyn_cast<DeclRefExpr>(E->getCallee()->IgnoreParenImpCasts())) {
+        Range = DRE->getSourceRange();
+      } else {
+        Range = E->getCallee()->getSourceRange();
+      }
+
+      if (Range.isValid()) {
+        Rewriter.ReplaceText(Range, Mangled);
+      }
+    }
+  }
+
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl *D) {
+  if (Context.getSourceManager().isInSystemHeader(D->getLocation()))
+    return true;
+
+  if (!D->isThisDeclarationADefinition())
+    return true;
+
+  std::string Mangled = mangleTemplateName(D);
+  std::string BaseName = D->getNameAsString();
+
+  std::string OriginalName;
+  llvm::raw_string_ostream OrigOS(OriginalName);
+  D->getNameForDiagnostic(OrigOS, Context.getPrintingPolicy(), true);
+  OrigOS.flush();
+  recordMangledName(Mangled, OriginalName);
+
+  std::string InstCode;
+  llvm::raw_string_ostream OS(InstCode);
+  PrintingPolicy Policy = Context.getPrintingPolicy();
+  Policy.IncludeTagDefinition = true;
+  Policy.TerseOutput = false;
+  Policy.Indentation = 2;
+
+  OS << "class " << Mangled << " {\n";
+  for (auto *Decl : D->decls()) {
+    if (Decl->isImplicit()) continue;
+
+    if (auto *AS = dyn_cast<AccessSpecDecl>(Decl)) {
+      if (AS->getAccess() == AS_public) OS << "public:\n";
+      else if (AS->getAccess() == AS_protected) OS << "protected:\n";
+      else OS << "private:\n";
+      continue;
+    }
+
+    std::string DeclCode;
+    llvm::raw_string_ostream DeclOS(DeclCode);
+
+    // graft the template pattern's body onto the instantiated method so
+    // print() emits it; this mutates the AST (the one exception to the
+    // no-mutation rule, the mutated decl is implicit anyway)
+    if (auto *MD = dyn_cast<CXXMethodDecl>(Decl)) {
+      if (!MD->isPure() && !MD->hasBody()) {
+        if (auto *Pattern = MD->getTemplateInstantiationPattern()) {
+          if (Pattern->hasBody()) {
+            MD->setInnerLocStart(Pattern->getInnerLocStart());
+            MD->setBody(Pattern->getBody());
+          }
+        }
+      }
+    }
+
+    Decl->print(DeclOS, Policy);
+    DeclOS.flush();
+
+    while (!DeclCode.empty() && std::isspace(DeclCode.back()))
+      DeclCode.pop_back();
+
+    OS << "  " << DeclCode;
+    if (!DeclCode.empty() && DeclCode.back() != ';' && DeclCode.back() != '}') {
+        OS << ";";
+    }
+    OS << "\n";
+  }
+  OS << "};\n";
+  OS.flush();
+
+  // uses of the specialised type inside the body get the mangled name
+  std::string FullSpecName;
+  llvm::raw_string_ostream SpecOS(FullSpecName);
+  D->getNameForDiagnostic(SpecOS, Policy, true);
+  SpecOS.flush();
+
+  if (!FullSpecName.empty()) {
+    size_t pos = 0;
+    while ((pos = InstCode.find(FullSpecName, pos)) != std::string::npos) {
+      InstCode.replace(pos, FullSpecName.length(), Mangled);
+      pos += Mangled.length();
+    }
+  }
+
+  // constructors and destructors carry the base name
+  std::regex BaseNameRegex("\\b" + escapeForRegex(BaseName) + "\\b");
+  InstCode = std::regex_replace(InstCode, BaseNameRegex, Mangled);
+
+  // insert before the template definition
+  if (ClassTemplateDecl *TD = D->getSpecializedTemplate()) {
+    SourceLocation InsertLoc = TD->getBeginLoc();
+    if (InsertLoc.isValid())
+      Rewriter.InsertTextBefore(
+          InsertLoc, InstCode + "\n\n",
+          originLineOf(Context.getSourceManager(), InsertLoc));
+  }
+
+  return true;
+}
+
+std::string CXXToCPlusTranslator::mangleFunctionName(const FunctionDecl *D) {
+  if (FunctionMangledNames.count(D)) return FunctionMangledNames[D];
+
+  std::string FullName;
+  llvm::raw_string_ostream OS(FullName);
+  D->getNameForDiagnostic(OS, Context.getPrintingPolicy(), true);
+  OS.flush();
+
+  std::string Mangled = flattenName(FullName);
+
+  FunctionMangledNames[D] = Mangled;
+  return Mangled;
+}
+
+std::string CXXToCPlusTranslator::mangleTemplateName(const ClassTemplateSpecializationDecl *D) {
+  if (MangledNames.count(D)) return MangledNames[D];
+
+  std::string FullName;
+  llvm::raw_string_ostream OS(FullName);
+  D->getNameForDiagnostic(OS, Context.getPrintingPolicy(), true);
+  OS.flush();
+
+  std::string Mangled = flattenName(FullName);
+
+  MangledNames[D] = Mangled;
+  return Mangled;
+}
+
+static std::string getTagKeyword(const CXXRecordDecl *RD) {
+  switch (RD->getTagKind()) {
+    case TTK_Class:  return "class";
+    case TTK_Struct: return "struct";
+    case TTK_Union:  return "union";
+    default:         return "";
+  }
+}
+
+
+bool CXXToCPlusTranslator::VisitTypeLoc(TypeLoc TL) {
+  if (Context.getSourceManager().isInSystemHeader(TL.getBeginLoc()))
+    return true;
+  if (insideRemovedTemplate(TL.getBeginLoc()))
+    return true;
+
+  PrintingPolicy Policy(Context.getLangOpts());
+  Policy.SuppressTagKeyword = false;
+  Policy.SuppressScope = false;
+  Policy.SuppressUnwrittenScope = false;
+
+  if (auto TSTL = TL.getAs<TemplateSpecializationTypeLoc>()) {
+    const TemplateSpecializationType *TST = TSTL.getTypePtr();
+    if (auto *RD = TST->getAsCXXRecordDecl()) {
+      if (auto *D = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
+        std::string elabTypeSpec = getTagKeyword(RD);
+        std::string NewName = elabTypeSpec + " " + mangleTemplateName(D);
+        Rewriter.ReplaceText(TSTL.getSourceRange(), NewName);
+      }
+    }
+  }
+  return true;
+}
+
+bool CXXToCPlusTranslator::shouldVisitTemplateInstantiations() const { return true; }
+bool CXXToCPlusTranslator::shouldVisitImplicitCode() const { return false; }
+
+
+bool CXXToCPlusTranslator::VisitFieldDecl(FieldDecl *Decl) {
+  if (VisitedDecls.count(Decl)) return true;
+  VisitedDecls.insert(Decl);
+  if (insideRemovedTemplate(Decl->getBeginLoc()))
+    return true;
+
+  QualType T = Decl->getType();
+  if (T->isRecordType()) {
+    std::string Name = Decl->getNameAsString();
+
+    PrintingPolicy Policy(Context.getLangOpts());
+    Policy.SuppressTagKeyword = false;
+    Policy.SuppressScope = false;
+    Policy.SuppressUnwrittenScope = false;
+
+    std::string NewName = T.getCanonicalType().getAsString(Policy) + " " + Name;
+    Rewriter.ReplaceText(Decl->getSourceRange(), NewName);
+  }
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitMemberExpr(MemberExpr *ME) {
+  if (VisitedMemberExprs.count(ME)) return true;
+  VisitedMemberExprs.insert(ME);
+  if (insideRemovedTemplate(ME->getMemberLoc()))
+    return true;
+
+  SourceLocation Loc = ME->getMemberLoc();
+  SourceManager &SM = Context.getSourceManager();
+
+  if (SM.isInSystemHeader(Loc) || Loc.isMacroID())
+    return true;
+
+  if (!ME->isImplicitAccess())
+    return true;
+
+  const FieldDecl *FD = dyn_cast<FieldDecl>(ME->getMemberDecl());
+  if (!FD)
+    return true;
+
+  if (isa<ClassTemplateSpecializationDecl>(FD->getParent()))
+    return true;
+
+  Rewriter.InsertText(Loc, "this->");
+
+  return true;
+}
+
+bool CXXToCPlusTranslator::VisitCXXThrowExpr(CXXThrowExpr *E) {
+  if (insideRemovedTemplate(E->getBeginLoc()))
+    return true;
+  if (const Expr *SubExpr = E->getSubExpr()) {
+    QualType T = SubExpr->getType();
+    PrintingPolicy Policy(Context.getLangOpts());
+    Policy.SuppressTagKeyword = false;
+    std::string TypeStr = T.getAsString(Policy);
+
+    Rewriter.InsertTextBefore(SubExpr->getBeginLoc(), "(" + TypeStr + ") (");
+    Rewriter.InsertTextAfterToken(SubExpr->getEndLoc(), ")");
+  }
+  return true;
+}
+
+
+bool CXXToCPlusTranslator::VisitCXXMemberCallExpr(CXXMemberCallExpr *CE) {
+  SourceManager &SM = Context.getSourceManager();
+  if (SM.isInSystemHeader(CE->getBeginLoc()))
+    return true;
+  if (insideRemovedTemplate(CE->getBeginLoc()))
+    return true;
+
+  MemberExpr *ME = dyn_cast<MemberExpr>(CE->getCallee()->IgnoreParenImpCasts());
+  if (!ME) return true;
+
+  if (ME->getQualifier()) return true; // already qualified
+
+  CXXMethodDecl *MD = CE->getMethodDecl();
+  if (!MD) return true;
+
+  if (MD->isImplicit()) return true;
+
+  // virtual calls are not statically dispatched, do not qualify them
+  if (MD->isVirtual()) return true;
+
+  CXXRecordDecl *RD = MD->getParent();
+  if (!RD) return true;
+
+  SourceLocation MemberLoc = ME->getMemberLoc();
+  if (MemberLoc.isInvalid() ||
+      (MemberLoc.isMacroID() && !SM.isMacroArgExpansion(MemberLoc)))
+    return true;
+
+  SourceLocation InsertLoc = SM.isMacroArgExpansion(MemberLoc)
+    ? SM.getSpellingLoc(MemberLoc)
+    : MemberLoc;
+
+  std::string QualName;
+  if (auto *Spec = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
+    QualName = mangleTemplateName(Spec) + "::";
+  } else {
+    QualName = RD->getQualifiedNameAsString() + "::";
+  }
+
+  Rewriter.InsertTextBefore(InsertLoc, QualName);
+  return true;
+}

--- a/lib/CharRewriter.cpp
+++ b/lib/CharRewriter.cpp
@@ -21,13 +21,13 @@ using namespace clang;
 using namespace ast_matchers;
 using namespace llvm;
 
-CharRewriter::CharRewriter(clang::Rewriter &r, clang::ASTContext &Ctx, 
+CharRewriter::CharRewriter(TrackedRewriter &r, clang::ASTContext &Ctx, 
                       UsedFunAndTypeCollector &usedFunsAndTypes) {
     CharRewriterASTConsumer c(r, usedFunsAndTypes);
     c.HandleTranslationUnit(Ctx);
 }
 
-CharRewriterASTConsumer::CharRewriterASTConsumer(clang::Rewriter &r,
+CharRewriterASTConsumer::CharRewriterASTConsumer(TrackedRewriter &r,
                                      UsedFunAndTypeCollector &usedFunsAndTypes)
                            : rewriter(r) {
   handler = std::make_unique<CharRewriterMatcher>(rewriter, usedFunsAndTypes);
@@ -43,15 +43,11 @@ void CharRewriterMatcher::run(const MatchFinder::MatchResult &Result) {
   const CharacterLiteral * charLit = 
     Result.Nodes.getNodeAs<clang::CharacterLiteral>("charLitExpr"); 
 
-  if (charLit) 
+  if (charLit)
   {
-    // comment out the original literal
-    wrapWithCComment(charLit->getSourceRange(), rewriter, true, false);
-    // add the integer value of the literal
-    rewriter.InsertTextBefore(charLit->getBeginLoc(),
-                 std::to_string(charLit->getValue())
-    );
-    
+    // replace the literal with its integer value
+    rewriter.ReplaceText(charLit->getSourceRange(),
+                         std::to_string(charLit->getValue()));
   } else {
     llvm_unreachable("CharRewriter unreachable case\n");
   }

--- a/lib/Determinizer.cpp
+++ b/lib/Determinizer.cpp
@@ -1,9 +1,10 @@
 #include "Determinizer.hpp"
+#include <algorithm>
 #include <sstream>
 #include "clang/Basic/SourceManager.h"
 #include "llvm/Support/raw_ostream.h"
 
-Determinizer::Determinizer(clang::Rewriter &R, clang::ASTContext &Ctx,
+Determinizer::Determinizer(TrackedRewriter &R, clang::ASTContext &Ctx,
                            const ExecutionCountAnalyzer &Analyzer)
     : TheRewriter(R), Context(Ctx), ExecAnalyzer(Analyzer) {
     run();
@@ -45,6 +46,26 @@ void Determinizer::run() {
     }
 }
 
+
+std::vector<std::string> Determinizer::addedInputArrays() const {
+    std::vector<std::string> names;
+    for (std::map<std::string, UnboundedInputInfo>::const_iterator it =
+             typeToArrayInfoMap.begin();
+         it != typeToArrayInfoMap.end(); ++it)
+        names.push_back(it->second.globalArrayName);
+    return names;
+}
+
+std::vector<std::string> Determinizer::addedInputVariables() const {
+    // headerInputNames holds both; the arrays are reported separately
+    std::vector<std::string> arrays = addedInputArrays();
+    std::vector<std::string> names;
+    for (size_t i = 0; i < headerInputNames.size(); ++i)
+        if (std::find(arrays.begin(), arrays.end(), headerInputNames[i]) ==
+            arrays.end())
+            names.push_back(headerInputNames[i]);
+    return names;
+}
 
 //===----------------------------------------------------------------------===//
 // DeterminizerVisitor Implementation

--- a/lib/FactsCollector.cpp
+++ b/lib/FactsCollector.cpp
@@ -199,5 +199,15 @@ bool writeFacts(StringRef path, const ProgramFacts &facts,
   out << "clockTokenSeen: " << (clockTokenSeen ? "true" : "false") << "\n";
   out << "durationTokenSeen: "
       << (durationTokenSeen ? "true" : "false") << "\n";
+  out << "# C++ names introduced by template instantiation, and what they"
+         " stand for\n";
+  if (facts.mangledNames.empty())
+    out << "mangledNames: []\n";
+  else {
+    out << "mangledNames:\n";
+    for (size_t i = 0; i < facts.mangledNames.size(); ++i)
+      out << "  - mangled: " << facts.mangledNames[i].mangled << "\n"
+          << "    original: \"" << facts.mangledNames[i].original << "\"\n";
+  }
   return true;
 }

--- a/lib/FactsCollector.cpp
+++ b/lib/FactsCollector.cpp
@@ -2,7 +2,9 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/StmtCXX.h"
 #include "clang/Basic/SourceManager.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
@@ -22,6 +24,8 @@ void collectFacts(ASTContext &Ctx, ProgramFacts &facts) {
   facts.allocationFunctions.clear();
   facts.usesArrays = false;
   facts.usesUnboundedArrays = false;
+  facts.usesThrow = false;
+  facts.usesTryCatch = false;
 
   class FactsVisitor : public RecursiveASTVisitor<FactsVisitor> {
   public:
@@ -57,6 +61,18 @@ void collectFacts(ASTContext &Ctx, ProgramFacts &facts) {
 
     bool VisitFieldDecl(FieldDecl *decl) {
       recordArrayDecl(decl->getType(), decl->getBeginLoc());
+      return true;
+    }
+
+    bool VisitCXXThrowExpr(CXXThrowExpr *expr) {
+      if (inMainFile(expr->getBeginLoc()))
+        facts.usesThrow = true;
+      return true;
+    }
+
+    bool VisitCXXTryStmt(CXXTryStmt *stmt) {
+      if (inMainFile(stmt->getBeginLoc()))
+        facts.usesTryCatch = true;
       return true;
     }
 
@@ -165,6 +181,9 @@ bool writeFacts(StringRef path, const ProgramFacts &facts,
   out << "usesArrays: " << (facts.usesArrays ? "true" : "false") << "\n";
   out << "usesUnboundedArrays: "
       << (facts.usesUnboundedArrays ? "true" : "false") << "\n";
+  out << "# C++ exceptions\n";
+  out << "usesThrow: " << (facts.usesThrow ? "true" : "false") << "\n";
+  out << "usesTryCatch: " << (facts.usesTryCatch ? "true" : "false") << "\n";
   out << "# inputs added by the determinizer (also in the INPUT header"
          " comment)\n";
   out << "inputVariables: [";
@@ -175,8 +194,8 @@ bool writeFacts(StringRef path, const ProgramFacts &facts,
   for (size_t i = 0; i < facts.inputArrays.size(); ++i)
     out << (i > 0 ? ", " : "") << facts.inputArrays[i];
   out << "]\n";
-  out << "# approximate: token-level scan for TriCera's clock/duration"
-         " extensions\n";
+  out << "# clock/duration are TriCera keywords; reported when the token"
+         " appears\n";
   out << "clockTokenSeen: " << (clockTokenSeen ? "true" : "false") << "\n";
   out << "durationTokenSeen: "
       << (durationTokenSeen ? "true" : "false") << "\n";

--- a/lib/FactsCollector.cpp
+++ b/lib/FactsCollector.cpp
@@ -1,0 +1,184 @@
+#include "FactsCollector.hpp"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <set>
+
+using namespace clang;
+using namespace llvm;
+
+// the allocation routines TriCera knows (Symex.scala)
+static const std::set<std::string> allocationFunctionNames = {
+    "malloc", "calloc", "realloc", "free", "alloca", "__builtin_alloca"
+};
+
+void collectFacts(ASTContext &Ctx, ProgramFacts &facts) {
+  facts.allocationFunctions.clear();
+  facts.usesArrays = false;
+  facts.usesUnboundedArrays = false;
+
+  class FactsVisitor : public RecursiveASTVisitor<FactsVisitor> {
+  public:
+    FactsVisitor(ASTContext &Ctx, ProgramFacts &facts)
+        : Ctx(Ctx), facts(facts) {}
+
+    bool VisitDeclRefExpr(DeclRefExpr *expr) {
+      const FunctionDecl *fun = dyn_cast<FunctionDecl>(expr->getDecl());
+      if (fun && allocationFunctionNames.count(fun->getNameAsString()) &&
+          inMainFile(expr->getBeginLoc()))
+        facts.allocationFunctions.insert(fun->getNameAsString());
+      return true;
+    }
+
+    bool VisitVarDecl(VarDecl *decl) {
+      // determinizer-added declarations are reported as inputs instead
+      std::string name = decl->getNameAsString();
+      if (std::find(facts.inputArrays.begin(), facts.inputArrays.end(),
+                    name) != facts.inputArrays.end() ||
+          std::find(facts.inputVariables.begin(), facts.inputVariables.end(),
+                    name) != facts.inputVariables.end())
+        return true;
+      // check the type as written: "int a[]" parameters decay to "int *"
+      // and a tentative "int a[];" is completed to int[1] in the AST
+      QualType typ = decl->getType();
+      if (const ParmVarDecl *parm = dyn_cast<ParmVarDecl>(decl))
+        typ = parm->getOriginalType();
+      else if (decl->getTypeSourceInfo())
+        typ = decl->getTypeSourceInfo()->getType();
+      recordArrayDecl(typ, decl->getBeginLoc());
+      return true;
+    }
+
+    bool VisitFieldDecl(FieldDecl *decl) {
+      recordArrayDecl(decl->getType(), decl->getBeginLoc());
+      return true;
+    }
+
+  private:
+    void recordArrayDecl(QualType typ, SourceLocation loc) {
+      if (!inMainFile(loc))
+        return;
+      if (typ.getCanonicalType()->isArrayType())
+        facts.usesArrays = true;
+      if (typ.getCanonicalType()->isIncompleteArrayType())
+        facts.usesUnboundedArrays = true;
+    }
+
+    // only the main file ends up in the produced program
+    bool inMainFile(SourceLocation loc) {
+      SourceManager &SM = Ctx.getSourceManager();
+      return loc.isValid() &&
+             SM.getDecomposedLoc(loc).first == SM.getMainFileID();
+    }
+
+    ASTContext &Ctx;
+    ProgramFacts &facts;
+  };
+
+  FactsVisitor visitor(Ctx, facts);
+  visitor.TraverseDecl(Ctx.getTranslationUnitDecl());
+}
+
+// token-level scan for an identifier, skipping comments, strings and char
+// literals; textual because clang cannot parse the TriCera extensions
+static bool containsIdentifier(StringRef text, StringRef name) {
+  enum class ScanState {
+    NORMAL, IN_BLOCK_COMMENT, IN_AT_COMMENT, IN_STRING, IN_CHAR_LITERAL,
+    IN_LINE_COMMENT
+  };
+  ScanState st = ScanState::NORMAL;
+  std::string ident;
+  for (unsigned i = 0; i < text.size(); ++i) {
+    char c = text[i];
+    char next = i + 1 < text.size() ? text[i + 1] : '\0';
+    switch (st) {
+    case ScanState::NORMAL:
+      if (c == '/' && next == '*') { st = ScanState::IN_BLOCK_COMMENT; ++i; }
+      else if (c == '/' && next == '/') { st = ScanState::IN_LINE_COMMENT; ++i; }
+      else if (c == '/' && next == '@') { st = ScanState::IN_AT_COMMENT; ++i; }
+      else if (c == '"') st = ScanState::IN_STRING;
+      else if (c == '\'') st = ScanState::IN_CHAR_LITERAL;
+      if (st != ScanState::NORMAL) {
+        if (ident == name) return true;
+        ident.clear();
+        break;
+      }
+      if (isalpha((unsigned char)c) || c == '_' ||
+          (!ident.empty() && isdigit((unsigned char)c)))
+        ident += c;
+      else {
+        if (ident == name) return true;
+        ident.clear();
+      }
+      break;
+    case ScanState::IN_BLOCK_COMMENT:
+      if (c == '*' && next == '/') { st = ScanState::NORMAL; ++i; }
+      break;
+    case ScanState::IN_AT_COMMENT:
+      if (c == '@' && next == '/') { st = ScanState::NORMAL; ++i; }
+      break;
+    case ScanState::IN_STRING:
+      if (c == '\\') ++i;
+      else if (c == '"') st = ScanState::NORMAL;
+      break;
+    case ScanState::IN_CHAR_LITERAL:
+      if (c == '\\') ++i;
+      else if (c == '\'') st = ScanState::NORMAL;
+      break;
+    case ScanState::IN_LINE_COMMENT:
+      if (c == '\\' && (next == '\n' || next == '\r')) ++i;
+      else if (c == '\n') st = ScanState::NORMAL;
+      break;
+    }
+  }
+  return ident == name;
+}
+
+bool writeFacts(StringRef path, const ProgramFacts &facts,
+                StringRef finalText, std::string &error) {
+  bool clockTokenSeen = containsIdentifier(finalText, "clock");
+  bool durationTokenSeen = containsIdentifier(finalText, "duration");
+
+  std::error_code ec;
+  raw_fd_ostream out(path, ec, sys::fs::OF_None);
+  if (ec) {
+    error = "cannot write facts file '" + path.str() + "': " + ec.message();
+    return false;
+  }
+  out << "---\n";
+  out << "# facts about the produced program; a missing fact means"
+         " \"not determined\"\n";
+  out << "# allocation functions the program references\n";
+  out << "allocationFunctions: [";
+  for (std::set<std::string>::const_iterator it =
+           facts.allocationFunctions.begin();
+       it != facts.allocationFunctions.end(); ++it)
+    out << (it != facts.allocationFunctions.begin() ? ", " : "") << *it;
+  out << "]\n";
+  out << "# declarations with array types / with arrays of unknown bound\n";
+  out << "usesArrays: " << (facts.usesArrays ? "true" : "false") << "\n";
+  out << "usesUnboundedArrays: "
+      << (facts.usesUnboundedArrays ? "true" : "false") << "\n";
+  out << "# inputs added by the determinizer (also in the INPUT header"
+         " comment)\n";
+  out << "inputVariables: [";
+  for (size_t i = 0; i < facts.inputVariables.size(); ++i)
+    out << (i > 0 ? ", " : "") << facts.inputVariables[i];
+  out << "]\n";
+  out << "inputArrays: [";
+  for (size_t i = 0; i < facts.inputArrays.size(); ++i)
+    out << (i > 0 ? ", " : "") << facts.inputArrays[i];
+  out << "]\n";
+  out << "# approximate: token-level scan for TriCera's clock/duration"
+         " extensions\n";
+  out << "clockTokenSeen: " << (clockTokenSeen ? "true" : "false") << "\n";
+  out << "durationTokenSeen: "
+      << (durationTokenSeen ? "true" : "false") << "\n";
+  return true;
+}

--- a/lib/ForLoopStmtExtractor.cpp
+++ b/lib/ForLoopStmtExtractor.cpp
@@ -20,13 +20,13 @@ using namespace clang;
 using namespace ast_matchers;
 using namespace llvm;
 
-ForLoopStmtExtractor::ForLoopStmtExtractor(clang::Rewriter &r, clang::ASTContext &Ctx, 
+ForLoopStmtExtractor::ForLoopStmtExtractor(TrackedRewriter &r, clang::ASTContext &Ctx, 
                       UsedFunAndTypeCollector &usedFunsAndTypes) {
     ForLoopStmtExtractorASTConsumer c(r, usedFunsAndTypes);
     c.HandleTranslationUnit(Ctx);
 }
 
-ForLoopStmtExtractorASTConsumer::ForLoopStmtExtractorASTConsumer(clang::Rewriter &r,
+ForLoopStmtExtractorASTConsumer::ForLoopStmtExtractorASTConsumer(TrackedRewriter &r,
                                      UsedFunAndTypeCollector &usedFunsAndTypes)
                            : rewriter(r) {
   handler = std::make_unique<ForLoopStmtExtractorMatcher>(rewriter, usedFunsAndTypes);
@@ -48,13 +48,13 @@ void ForLoopStmtExtractorMatcher::run(const MatchFinder::MatchResult &Result) {
   const DeclStmt * declStmt =
     Result.Nodes.getNodeAs<clang::DeclStmt>("declStmt"); 
 
-  if (forStmt && declStmt) 
+  if (forStmt && declStmt)
   { // get the decl. text from inside the for loop and move it before the loop
-    rewriter.InsertTextBefore(forStmt->getBeginLoc(), 
+    rewriter.InsertTextBefore(forStmt->getBeginLoc(),
       "{ " + rewriter.getRewrittenText(declStmt->getSourceRange()) + " "
     );
-    // comment out the decl. inside the for loop
-    wrapWithCComment(declStmt->getSourceRange(), rewriter);
+    // remove the decl., keep its semicolon as the for-init terminator
+    rewriter.BlankChars(declStmt->getBeginLoc(), declStmt->getEndLoc());
     // close the compound stmt after the loop
     rewriter.InsertTextAfter(forStmt->getEndLoc(), "}");
   } else {

--- a/lib/LineMarkerEmitter.cpp
+++ b/lib/LineMarkerEmitter.cpp
@@ -1,0 +1,270 @@
+#include "LineMarkerEmitter.hpp"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <vector>
+
+using namespace clang;
+using namespace llvm;
+
+// offsets at which each line starts (line i, 1-based, starts at result[i-1])
+static std::vector<unsigned> lineStartsOf(StringRef text) {
+  std::vector<unsigned> starts;
+  starts.push_back(0);
+  for (unsigned i = 0; i < text.size(); ++i)
+    if (text[i] == '\n')
+      starts.push_back(i + 1);
+  // a final newline opens no further line
+  if (!starts.empty() && starts.back() == text.size() && text.size() > 0)
+    starts.pop_back();
+  return starts;
+}
+
+// 1-based line containing `offset`, via binary search over line starts
+static unsigned lineAt(const std::vector<unsigned> &starts, unsigned offset) {
+  unsigned lo = 0, hi = (unsigned)starts.size();
+  while (lo + 1 < hi) {
+    unsigned mid = (lo + hi) / 2;
+    if (starts[mid] <= offset)
+      lo = mid;
+    else
+      hi = mid;
+  }
+  return lo + 1;
+}
+
+// a linemarker or #line directive; such lines come from cpp or an earlier
+// tri-pp stage and must not be passed through
+static bool isMarkerLine(StringRef line) {
+  size_t i = 0;
+  while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+  if (i >= line.size() || line[i] != '#') return false;
+  ++i;
+  while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+  if (line.substr(i).startswith("line")) {
+    i += 4;
+    if (i >= line.size() || (line[i] != ' ' && line[i] != '\t')) return false;
+    while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+  }
+  if (i >= line.size() || line[i] < '0' || line[i] > '9') return false;
+  return true;
+}
+
+// markers may only be inserted where a line starts outside any comment or
+// string literal
+enum class ScanState {
+  NORMAL,
+  IN_BLOCK_COMMENT,  // /* ... */ including ACSL /*@ ... */ and /*$ ... $*/
+  IN_AT_COMMENT,     // /@ ... @/ (TriCera ACSL variant)
+  IN_STRING,         // "..." continued over a backslash-newline
+  IN_CHAR_LITERAL,   // '...' continued over a backslash-newline
+  IN_LINE_COMMENT    // // ... continued over a backslash-newline
+};
+
+// state of `text` at the start of each line (index = line - 1)
+static std::vector<ScanState> scanStatesAtLineStarts(StringRef text) {
+  std::vector<ScanState> states;
+  ScanState st = ScanState::NORMAL;
+  states.push_back(st);
+  for (unsigned i = 0; i < text.size(); ++i) {
+    char c = text[i];
+    char next = i + 1 < text.size() ? text[i + 1] : '\0';
+    switch (st) {
+    case ScanState::NORMAL:
+      if (c == '/' && next == '*') { st = ScanState::IN_BLOCK_COMMENT; ++i; }
+      else if (c == '/' && next == '/') { st = ScanState::IN_LINE_COMMENT; ++i; }
+      else if (c == '/' && next == '@') { st = ScanState::IN_AT_COMMENT; ++i; }
+      else if (c == '"') st = ScanState::IN_STRING;
+      else if (c == '\'') st = ScanState::IN_CHAR_LITERAL;
+      break;
+    case ScanState::IN_BLOCK_COMMENT:
+      if (c == '*' && next == '/') { st = ScanState::NORMAL; ++i; }
+      break;
+    case ScanState::IN_AT_COMMENT:
+      if (c == '@' && next == '/') { st = ScanState::NORMAL; ++i; }
+      break;
+    case ScanState::IN_STRING:
+      if (c == '\\') ++i; // skip escaped char (also a backslash-newline)
+      else if (c == '"') st = ScanState::NORMAL;
+      break;
+    case ScanState::IN_CHAR_LITERAL:
+      if (c == '\\') ++i;
+      else if (c == '\'') st = ScanState::NORMAL;
+      break;
+    case ScanState::IN_LINE_COMMENT:
+      if (c == '\\' && (next == '\n' || next == '\r')) ++i; // continued
+      else if (c == '\n') st = ScanState::NORMAL;
+      break;
+    }
+    if (i >= text.size()) // ++i above may step past the end
+      break;
+    if (text[i] == '\n')
+      states.push_back(st);
+  }
+  return states;
+}
+
+bool emitLineMarkers(StringRef original, StringRef rewritten,
+                     const EditTracker &tracker, SourceManager &SM,
+                     std::string &result, std::string &error) {
+  // the log must reproduce the buffer exactly, otherwise the markers
+  // would be fiction
+  std::string replayed = tracker.apply(original);
+  if (StringRef(replayed) != rewritten) {
+    error = "tracked edits do not reproduce the rewritten output; "
+            "an edit bypassed the TrackedRewriter";
+    return false;
+  }
+
+  std::vector<NetEdit> nets = tracker.disjointEdits(original);
+  std::vector<unsigned> origStarts = lineStartsOf(original);
+  std::vector<unsigned> outStarts = lineStartsOf(rewritten);
+  unsigned numOutLines = (unsigned)outStarts.size();
+
+  // claimedBy[o-1]: first original line whose start maps into output line
+  // o (0 = inserted text only). originOf[o-1]: for unclaimed lines, the
+  // original line the inserted text is attributed to.
+  std::vector<unsigned> claimedBy(numOutLines, 0);
+  std::vector<unsigned> originOf(numOutLines, 0);
+
+  // walk the pieces [unchanged span | edit text]* in step with the output
+  {
+    unsigned origPos = 0; // position in original
+    unsigned outPos = 0;  // position in rewritten
+    size_t netIdx = 0;
+    while (origPos <= original.size()) {
+      unsigned spanEnd = netIdx < nets.size() ? nets[netIdx].offset
+                                              : (unsigned)original.size();
+      // unchanged original span [origPos, spanEnd)
+      for (unsigned L = lineAt(origStarts, origPos); L <= origStarts.size();
+           ++L) {
+        unsigned start = origStarts[L - 1];
+        if (start >= spanEnd)
+          break;
+        if (start >= origPos) {
+          unsigned mapped = outPos + (start - origPos);
+          unsigned outLine = lineAt(outStarts, mapped);
+          if (claimedBy[outLine - 1] == 0)
+            claimedBy[outLine - 1] = L;
+        }
+      }
+      outPos += spanEnd - origPos;
+      origPos = spanEnd;
+      if (netIdx >= nets.size())
+        break;
+      // edit text replacing [origPos, origPos+length)
+      const NetEdit &n = nets[netIdx];
+      unsigned anchorLine = n.originLine
+                                ? n.originLine
+                                : lineAt(origStarts, n.offset);
+      unsigned editOutEnd = outPos + (unsigned)n.text.size();
+      // attribute output lines starting inside the edit text
+      unsigned firstCand = lineAt(outStarts, outPos);
+      if (outStarts[firstCand - 1] != outPos)
+        ++firstCand; // the edit starts mid-line
+      for (unsigned o = firstCand;
+           o <= numOutLines && outStarts[o - 1] < editOutEnd; ++o)
+        if (originOf[o - 1] == 0)
+          originOf[o - 1] = anchorLine;
+      outPos = editOutEnd;
+      origPos = n.offset + n.length;
+      ++netIdx;
+      if (origPos > original.size())
+        break;
+    }
+  }
+
+  // presumed location of each original line (this consumes incoming
+  // linemarkers)
+  FileID mainFID = SM.getMainFileID();
+  std::vector<unsigned> presumedLine(origStarts.size() + 1, 0);
+  std::vector<std::string> presumedFile(origStarts.size() + 1);
+  for (unsigned L = 1; L <= origStarts.size(); ++L) {
+    SourceLocation loc = SM.translateLineCol(mainFID, L, 1);
+    PresumedLoc ploc = SM.getPresumedLoc(loc);
+    if (ploc.isValid()) {
+      presumedLine[L] = ploc.getLine();
+      presumedFile[L] = ploc.getFilename();
+    } else {
+      presumedLine[L] = L;
+      presumedFile[L] = "<unknown>";
+    }
+  }
+
+  // input marker lines are consumed above and must not pass through
+  std::vector<bool> origIsMarker(origStarts.size() + 1, false);
+  {
+    std::vector<ScanState> origStates = scanStatesAtLineStarts(original);
+    for (unsigned L = 1; L <= origStarts.size(); ++L) {
+      unsigned end = L < origStarts.size() ? origStarts[L] : (unsigned)original.size();
+      StringRef line = original.substr(origStarts[L - 1], end - origStarts[L - 1]);
+      if (L - 1 < origStates.size() && origStates[L - 1] == ScanState::NORMAL &&
+          isMarkerLine(line))
+        origIsMarker[L] = true;
+    }
+  }
+
+  std::vector<ScanState> outStates = scanStatesAtLineStarts(rewritten);
+
+  // splice in the markers, simulating the consumer: a marker means "the
+  // next line is line N of file F", every line advances the count by one
+  result.clear();
+  result.reserve(rewritten.size() + 256);
+  // before any marker the mapping is the identity; the file is named the
+  // way presumed locations name it with no directive in effect, so on-disk
+  // and in-memory (later round) inputs agree
+  PresumedLoc firstLoc = SM.getPresumedLoc(SM.getLocForStartOfFile(mainFID),
+                                           /*UseLineDirectives=*/false);
+  std::string consumerFile =
+      firstLoc.isValid() ? firstLoc.getFilename() : "<unknown>";
+  long consumerNext = 1; // line number the consumer gives the next line
+  for (unsigned o = 1; o <= numOutLines; ++o) {
+    unsigned end = o < numOutLines ? outStarts[o] : (unsigned)rewritten.size();
+    StringRef lineText = rewritten.substr(outStarts[o - 1],
+                                          end - outStarts[o - 1]);
+    unsigned orig = claimedBy[o - 1];
+
+    // drop stale input marker lines; their effect is already part of the
+    // presumed locations, and the next claimed line re-syncs below
+    if (orig != 0 && origIsMarker[orig])
+      continue;
+
+    unsigned intendedLine = 0;
+    const std::string *intendedFile = nullptr;
+    if (orig != 0) {
+      intendedLine = presumedLine[orig];
+      intendedFile = &presumedFile[orig];
+    } else {
+      unsigned originAt = originOf[o - 1];
+      // only the first line of a run of inserted lines gets a marker, the
+      // rest continue from it
+      bool firstOfRun = o == 1 || claimedBy[o - 2] != 0 ||
+                        originOf[o - 2] != originAt;
+      if (originAt != 0 && firstOfRun) {
+        intendedLine = presumedLine[originAt];
+        intendedFile = &presumedFile[originAt];
+      }
+    }
+
+    if (intendedLine != 0 &&
+        (consumerNext != (long)intendedLine ||
+         consumerFile != *intendedFile)) {
+      // emit only at safe line starts; when unsafe, the mismatch persists
+      // and the marker comes at the next safe line instead
+      if (o - 1 < outStates.size() && outStates[o - 1] == ScanState::NORMAL) {
+        result += "# ";
+        result += std::to_string(intendedLine);
+        result += " \"";
+        result += *intendedFile;
+        result += "\"\n";
+        consumerNext = intendedLine;
+        consumerFile = *intendedFile;
+      }
+    }
+
+    result += lineText;
+    ++consumerNext;
+  }
+
+  return true;
+}

--- a/lib/NondetLoopGuardRewriter.cpp
+++ b/lib/NondetLoopGuardRewriter.cpp
@@ -14,7 +14,7 @@
 
 using namespace clang;
 
-NondetLoopGuardRewriter::NondetLoopGuardRewriter(Rewriter &R, ASTContext &Ctx)
+NondetLoopGuardRewriter::NondetLoopGuardRewriter(TrackedRewriter &R, ASTContext &Ctx)
         : rewriter(R), context(Ctx), tempLoopIdxCounter(0) {
 
     TraverseDecl(Ctx.getTranslationUnitDecl());
@@ -47,15 +47,15 @@ void NondetLoopGuardRewriter::rewriteWhileStmt(WhileStmt *S) {
 
     const auto *callExpr = cast<CallExpr>(S->getCond()->IgnoreParenImpCasts());
     std::string tempVarName = "__loop_idx_" + std::to_string(tempLoopIdxCounter++);
-    std::string callText = Lexer::getSourceText(
-            CharSourceRange::getTokenRange(callExpr->getSourceRange()),
-            sm, langOpts).str();
+    std::string callText = rewriter.getRewrittenText(callExpr->getSourceRange());
 
     std::string prefix;
     llvm::raw_string_ostream ss(prefix);
     ss << "{ int " << tempVarName << " = " << callText << "; ";
     rewriter.InsertTextBefore(S->getBeginLoc(), ss.str());
-    rewriter.ReplaceText(S->getCond()->getSourceRange(), tempVarName + "-->0");
+    // blank the guard and put the counter check in its place
+    rewriter.BlankText(S->getCond()->getSourceRange());
+    rewriter.InsertTextBefore(S->getCond()->getBeginLoc(), tempVarName + "-->0");
 
     Stmt *body = S->getBody();
     if (!isa<CompoundStmt>(body)) {

--- a/lib/TrackedRewriter.cpp
+++ b/lib/TrackedRewriter.cpp
@@ -81,7 +81,8 @@ bool TrackedRewriter::InsertText(SourceLocation Loc, StringRef Str,
   return false;
 }
 
-bool TrackedRewriter::InsertTextAfterToken(SourceLocation Loc, StringRef Str) {
+bool TrackedRewriter::InsertTextAfterToken(SourceLocation Loc, StringRef Str,
+                                           unsigned originLine) {
   if (!Rewriter::isRewritable(Loc))
     return true;
   unsigned tokLen = Lexer::MeasureTokenLength(Loc, rewriter.getSourceMgr(),
@@ -89,7 +90,7 @@ bool TrackedRewriter::InsertTextAfterToken(SourceLocation Loc, StringRef Str) {
   if (rewriter.InsertTextAfterToken(Loc, Str))
     return true;
   recordAt(Loc, tokLen, TrackedEdit::Kind::INSERTION, 0, Str,
-           /*insertAfter=*/true);
+           /*insertAfter=*/true, originLine);
   return false;
 }
 

--- a/lib/TrackedRewriter.cpp
+++ b/lib/TrackedRewriter.cpp
@@ -1,0 +1,326 @@
+#include "TrackedRewriter.hpp"
+
+#include "clang/Lex/Lexer.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <algorithm>
+#include <map>
+#include <utility>
+
+using namespace clang;
+using namespace llvm;
+
+//===----------------------------------------------------------------------===//
+// TrackedRewriter
+//===----------------------------------------------------------------------===//
+
+void TrackedRewriter::recordAt(SourceLocation Loc, unsigned extraOffset,
+                               TrackedEdit::Kind kind, unsigned length,
+                               StringRef text, bool insertAfter,
+                               unsigned originLine) {
+  SourceManager &SM = rewriter.getSourceMgr();
+  std::pair<FileID, unsigned> loc = SM.getDecomposedLoc(Loc);
+  if (loc.first != SM.getMainFileID())
+    return; // only main-file edits reach the output buffer
+  tracker.record(activeTransformer, kind, loc.second + extraOffset, length,
+                 text, insertAfter, originLine);
+}
+
+// same predicate Rewriter::InsertText uses for indentNewLines
+static bool isWhitespaceExceptNL(unsigned char c) {
+  switch (c) {
+  case ' ':
+  case '\t':
+  case '\f':
+  case '\v':
+  case '\r':
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool TrackedRewriter::InsertText(SourceLocation Loc, StringRef Str,
+                                 bool InsertAfter, bool indentNewLines,
+                                 unsigned originLine) {
+  if (!Rewriter::isRewritable(Loc))
+    return true;
+
+  // expand indentNewLines like Rewriter::InsertText would, so the recorded
+  // text equals the buffer text
+  SmallString<128> indentedStr;
+  if (indentNewLines && Str.contains('\n')) {
+    SourceManager &SM = rewriter.getSourceMgr();
+    std::pair<FileID, unsigned> loc = SM.getDecomposedLoc(Loc);
+    StringRef MB = SM.getBufferData(loc.first);
+    unsigned lineNo = SM.getLineNumber(loc.first, loc.second);
+    unsigned lineOffs = SM.getDecomposedLoc(
+        SM.translateLineCol(loc.first, lineNo, 1)).second;
+    unsigned i = lineOffs;
+    while (i < MB.size() && isWhitespaceExceptNL(MB[i]))
+      ++i;
+    StringRef indentSpace = MB.substr(lineOffs, i - lineOffs);
+
+    SmallVector<StringRef, 4> lines;
+    Str.split(lines, "\n");
+    for (unsigned l = 0, e = lines.size(); l != e; ++l) {
+      indentedStr += lines[l];
+      if (l < e - 1) {
+        indentedStr += '\n';
+        indentedStr += indentSpace;
+      }
+    }
+    Str = indentedStr.str();
+  }
+
+  if (rewriter.InsertText(Loc, Str, InsertAfter, /*indentNewLines=*/false))
+    return true;
+  recordAt(Loc, 0, TrackedEdit::Kind::INSERTION, 0, Str, InsertAfter,
+           originLine);
+  return false;
+}
+
+bool TrackedRewriter::InsertTextAfterToken(SourceLocation Loc, StringRef Str) {
+  if (!Rewriter::isRewritable(Loc))
+    return true;
+  unsigned tokLen = Lexer::MeasureTokenLength(Loc, rewriter.getSourceMgr(),
+                                              rewriter.getLangOpts());
+  if (rewriter.InsertTextAfterToken(Loc, Str))
+    return true;
+  recordAt(Loc, tokLen, TrackedEdit::Kind::INSERTION, 0, Str,
+           /*insertAfter=*/true);
+  return false;
+}
+
+bool TrackedRewriter::ReplaceText(SourceRange range, StringRef NewStr) {
+  SourceLocation B = range.getBegin(), E = range.getEnd();
+  if (!Rewriter::isRewritable(B) || !Rewriter::isRewritable(E))
+    return true;
+
+  SourceManager &SM = rewriter.getSourceMgr();
+  std::pair<FileID, unsigned> beg = SM.getDecomposedLoc(B);
+  std::pair<FileID, unsigned> end = SM.getDecomposedLoc(E);
+  if (beg.first != end.first || end.second < beg.second)
+    return true; // Rewriter::getRangeSize would report -1 for these
+
+  if (rewriter.ReplaceText(range, NewStr))
+    return true;
+
+  // length of the original token range
+  unsigned tokLen = Lexer::MeasureTokenLength(E, SM, rewriter.getLangOpts());
+  recordAt(B, 0, TrackedEdit::Kind::REPLACEMENT,
+           end.second + tokLen - beg.second, NewStr, /*insertAfter=*/true);
+  return false;
+}
+
+// whitespace of the same geometry as the original buffer at [offset,
+// offset+length): newlines kept, everything else a space
+static std::string whitespaceFor(StringRef buf, unsigned offset,
+                                 unsigned length) {
+  std::string spaces;
+  spaces.reserve(length);
+  for (unsigned i = 0; i < length; ++i) {
+    char c = buf[offset + i];
+    spaces += (c == '\n' || c == '\r') ? c : ' ';
+  }
+  return spaces;
+}
+
+bool TrackedRewriter::BlankText(SourceRange range) {
+  SourceLocation B = range.getBegin(), E = range.getEnd();
+  if (!Rewriter::isRewritable(B) || !Rewriter::isRewritable(E))
+    return true;
+
+  SourceManager &SM = rewriter.getSourceMgr();
+  std::pair<FileID, unsigned> beg = SM.getDecomposedLoc(B);
+  std::pair<FileID, unsigned> end = SM.getDecomposedLoc(E);
+  if (beg.first != end.first || end.second < beg.second)
+    return true;
+
+  unsigned tokLen = Lexer::MeasureTokenLength(E, SM, rewriter.getLangOpts());
+  unsigned length = end.second + tokLen - beg.second;
+  StringRef buf = SM.getBufferData(beg.first);
+  if (beg.second + length > buf.size())
+    return true;
+
+  std::string spaces = whitespaceFor(buf, beg.second, length);
+  if (rewriter.ReplaceText(range, spaces))
+    return true;
+  recordAt(B, 0, TrackedEdit::Kind::BLANK, length, spaces,
+           /*insertAfter=*/true);
+  return false;
+}
+
+bool TrackedRewriter::BlankChars(SourceLocation B, SourceLocation E) {
+  if (!Rewriter::isRewritable(B) || !Rewriter::isRewritable(E))
+    return true;
+
+  SourceManager &SM = rewriter.getSourceMgr();
+  std::pair<FileID, unsigned> beg = SM.getDecomposedLoc(B);
+  std::pair<FileID, unsigned> end = SM.getDecomposedLoc(E);
+  if (beg.first != end.first || end.second < beg.second)
+    return true;
+
+  unsigned length = end.second - beg.second;
+  if (length == 0)
+    return false;
+  StringRef buf = SM.getBufferData(beg.first);
+  if (beg.second + length > buf.size())
+    return true;
+
+  std::string spaces = whitespaceFor(buf, beg.second, length);
+  if (rewriter.ReplaceText(B, length, spaces))
+    return true;
+  recordAt(B, 0, TrackedEdit::Kind::BLANK, length, spaces,
+           /*insertAfter=*/true);
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// EditTracker
+//===----------------------------------------------------------------------===//
+
+std::vector<TrackedEdit> EditTracker::editsWithoutRepeats() const {
+  // a repeated identical replacement changes nothing (TypeCanoniser runs
+  // its sizeof matcher twice); keep the first
+  std::vector<TrackedEdit> result;
+  for (size_t i = 0; i < edits.size(); ++i) {
+    const TrackedEdit &e = edits[i];
+    if (!e.isInsertion()) {
+      bool repeated = false;
+      for (size_t j = 0; j < result.size(); ++j) {
+        const TrackedEdit &p = result[j];
+        if (!p.isInsertion() && p.offset == e.offset &&
+            p.length == e.length && p.text == e.text) {
+          repeated = true;
+          break;
+        }
+      }
+      if (repeated)
+        continue;
+    }
+    result.push_back(e);
+  }
+  return result;
+}
+
+std::vector<std::pair<TrackedEdit, TrackedEdit> >
+EditTracker::nonCommutingPairs() const {
+  std::vector<std::pair<TrackedEdit, TrackedEdit> > pairs;
+  std::vector<TrackedEdit> es = editsWithoutRepeats(); // application order
+  for (size_t i = 0; i < es.size(); ++i) {
+    for (size_t j = i + 1; j < es.size(); ++j) {
+      const TrackedEdit &a = es[i], &b = es[j];
+      bool sameTransformer = a.transformer == b.transformer;
+      bool clash;
+      if (a.isInsertion() && b.isInsertion()) {
+        // same-offset insertions compose, but only deliberately so within
+        // one transformer
+        clash = a.offset == b.offset && !sameTransformer;
+      } else if (a.isInsertion() != b.isInsertion()) {
+        const TrackedEdit &ins = a.isInsertion() ? a : b;
+        const TrackedEdit &rep = a.isInsertion() ? b : a;
+        // an insertion inside a replaced range; the edges are fine
+        clash = rep.offset < ins.offset &&
+                ins.offset < rep.offset + rep.length;
+      } else if (a.isBlank() && b.isBlank() && sameTransformer) {
+        // overlapping blanks give their union either way
+        clash = false;
+      } else {
+        // no other replacements may intersect
+        clash = a.offset < b.offset + b.length &&
+                b.offset < a.offset + a.length;
+      }
+      if (clash)
+        pairs.push_back(std::make_pair(a, b));
+    }
+  }
+  return pairs;
+}
+
+std::vector<NetEdit> EditTracker::disjointEdits(StringRef original) const {
+  std::vector<TrackedEdit> es = editsWithoutRepeats();
+
+  // 1. merge overlapping blanks into their union
+  std::vector<std::pair<unsigned, unsigned> > blankIvs; // [start, end)
+  for (size_t i = 0; i < es.size(); ++i)
+    if (es[i].isBlank())
+      blankIvs.push_back(std::make_pair(es[i].offset,
+                                        es[i].offset + es[i].length));
+  std::sort(blankIvs.begin(), blankIvs.end());
+  std::vector<std::pair<unsigned, unsigned> > merged;
+  for (size_t i = 0; i < blankIvs.size(); ++i) {
+    if (!merged.empty() && blankIvs[i].first <= merged.back().second)
+      merged.back().second = std::max(merged.back().second, blankIvs[i].second);
+    else
+      merged.push_back(blankIvs[i]);
+  }
+
+  // 2. group by offset and compose like RewriteBuffer: InsertAfter
+  //    appends, InsertBefore prepends, replacement text comes last
+  struct OffsetState {
+    std::string insertText;
+    std::string replaceText;
+    unsigned replaceLen;
+    unsigned originLine;
+    OffsetState() : replaceLen(0), originLine(0) {}
+  };
+  std::map<unsigned, OffsetState> byOffset;
+  for (size_t i = 0; i < es.size(); ++i) {
+    const TrackedEdit &e = es[i];
+    if (e.isBlank())
+      continue; // added from `merged` below
+    OffsetState &s = byOffset[e.offset];
+    if (e.isInsertion())
+      s.insertText = e.insertAfter ? s.insertText + e.text
+                                   : e.text + s.insertText;
+    else {
+      // conflict detection guarantees at most one replacement per offset
+      s.replaceText = e.text;
+      s.replaceLen = e.length;
+    }
+    if (s.originLine == 0)
+      s.originLine = e.originLine;
+  }
+  for (size_t i = 0; i < merged.size(); ++i) {
+    OffsetState &s = byOffset[merged[i].first];
+    unsigned len = merged[i].second - merged[i].first;
+    s.replaceLen = len;
+    s.replaceText.clear();
+    for (unsigned k = 0; k < len; ++k) {
+      char c = merged[i].first + k < original.size()
+                   ? original[merged[i].first + k] : ' ';
+      s.replaceText += (c == '\n' || c == '\r') ? c : ' ';
+    }
+  }
+
+  std::vector<NetEdit> result;
+  for (std::map<unsigned, OffsetState>::iterator it = byOffset.begin();
+       it != byOffset.end(); ++it) {
+    NetEdit n;
+    n.offset = it->first;
+    n.length = it->second.replaceLen;
+    n.text = it->second.insertText + it->second.replaceText;
+    n.originLine = it->second.originLine;
+    result.push_back(n);
+  }
+  return result;
+}
+
+std::string EditTracker::apply(StringRef original) const {
+  std::vector<NetEdit> nets = disjointEdits(original);
+  std::string out;
+  out.reserve(original.size());
+  unsigned pos = 0;
+  for (size_t i = 0; i < nets.size(); ++i) {
+    const NetEdit &n = nets[i];
+    if (n.offset > original.size() || n.offset < pos)
+      break; // defensive; cannot happen for in-range, conflict-free edits
+    out.append(original.data() + pos, original.data() + n.offset);
+    out.append(n.text);
+    pos = n.offset + n.length;
+  }
+  out.append(original.data() + pos, original.data() + original.size());
+  return out;
+}

--- a/lib/TriceraPreprocessor.cpp
+++ b/lib/TriceraPreprocessor.cpp
@@ -20,55 +20,53 @@
 using namespace clang;
 using namespace ast_matchers;
 using namespace std;
-extern llvm::cl::opt<bool> determinize;
-extern llvm::cl::opt<bool> makeCallsUnique;
 extern llvm::cl::opt<bool> noDeclSlice;
 extern llvm::cl::opt<std::string> entryFunctionName;
-extern llvm::cl::opt<std::string> encode;
+extern llvm::cl::opt<std::string> factsFilename;
 
 #include <string>
 
 //-----------------------------------------------------------------------------
 //
 //-----------------------------------------------------------------------------
-void MainConsumer::HandleTranslationUnit(clang::ASTContext& Ctx) {
-
-  // todo: process files where an error has occurred?
-  // errors also occur on some inputs which TriCera would accept
-  bool hadError = Ctx.getDiagnostics().hasErrorOccurred();
-  bool collectAllFuns = hadError || noDeclSlice;
-  bool collectAllTypes = hadError || noDeclSlice;
-  // todo: or return without doing anything?
-  // if (Ctx.getDiagnostics().hasErrorOccurred()) return;
-
-  // collect all used functions and types
-  UsedFunAndTypeCollector usedFunsAndTypes(Ctx, collectAllFuns,
-                                           collectAllTypes);
-
-  if (makeCallsUnique) {
-    UniqueCallTransformer uniqueCaller(rewriter, Ctx, usedFunsAndTypes);
-    uniqueCaller.transform();
-  } else if (determinize) {
-    ExecutionCountAnalyzer execAnalyzer(Ctx, usedFunsAndTypes, entryFunctionName);
-    // execAnalyzer.printFrequencies(llvm::outs()); // only for debugging
-    Determinizer determinizer(rewriter, Ctx, execAnalyzer);
-  } else { // Run the default stages
-    // then remove all typedefs and remove unused record typedef declarations
-    TypedefRemover typedefRemover(rewriter, Ctx, usedFunsAndTypes);
-    // then comment out all unused declarations
-    if (!hadError && !noDeclSlice)
-      UnusedDeclCommenter declCommenter(rewriter, Ctx, usedFunsAndTypes);
-    // and canonise all used types
+void MainConsumer::runStage(Stage stage, clang::ASTContext &Ctx,
+                            UsedFunAndTypeCollector &usedFunsAndTypes,
+                            bool hadError) {
+  switch (stage) {
+  case Stage::TYPE_CANONISE: {
+    // canonise all used types
+    rewriter.setActiveTransformer("TypeCanoniser");
     TypeCanoniser typeCanoniser(rewriter, Ctx, usedFunsAndTypes);
-    // extract declStmts from inside for loop declarations
-    ForLoopStmtExtractor forLoopStmtExtractor(rewriter, Ctx, usedFunsAndTypes);
-    // replace char init expressions with their corresponding integer values
+    break;
+  }
+  case Stage::TYPEDEF_REMOVE: {
+    // remove all typedefs; their uses were canonised in an earlier round
+    rewriter.setActiveTransformer("TypedefRemover");
+    TypedefRemover typedefRemover(rewriter, Ctx, usedFunsAndTypes);
+    break;
+  }
+  case Stage::CHAR_REWRITE: {
+    // replace char literals with their corresponding integer values
+    rewriter.setActiveTransformer("CharRewriter");
     CharRewriter charRewriter(rewriter, Ctx, usedFunsAndTypes);
-    // rewrite while loops with nondet (extern) function calls in their guards
-    // "while(nondet())" --> "{tmp = nondet(); while(tmp-->0)}"
+    break;
+  }
+  case Stage::FOR_LOOP_EXTRACT: {
+    // extract declStmts from inside for loop declarations
+    rewriter.setActiveTransformer("ForLoopStmtExtractor");
+    ForLoopStmtExtractor forLoopStmtExtractor(rewriter, Ctx, usedFunsAndTypes);
+    break;
+  }
+  case Stage::NONDET_LOOP_GUARD_REWRITE: {
+    // rewrite while loops with nondet (extern) function calls in their
+    // guards: "while(nondet())" --> "{tmp = nondet(); while(tmp-->0)}"
+    rewriter.setActiveTransformer("NondetLoopGuardRewriter");
     NondetLoopGuardRewriter externLoopRewriter(rewriter, Ctx);
-
-    // finally add contract annotations to recursive functions
+    break;
+  }
+  case Stage::CONTRACT_ANNOTATE: {
+    // add contract annotations to recursive functions
+    rewriter.setActiveTransformer("RecursiveFunAnnotator");
     preprocessOutput.numRecursiveFuns = 0;
     for (auto funInfo : usedFunsAndTypes.getSeenFunctions()) {
       if (funInfo->isRecursive()) {
@@ -80,7 +78,69 @@ void MainConsumer::HandleTranslationUnit(clang::ASTContext& Ctx) {
         }
       }
     }
+    break;
   }
+  case Stage::UNUSED_DECL_REMOVE: {
+    // remove all unused declarations
+    if (!hadError && !noDeclSlice) {
+      rewriter.setActiveTransformer("UnusedDeclCommenter");
+      UnusedDeclCommenter declCommenter(rewriter, Ctx, usedFunsAndTypes);
+    }
+    break;
+  }
+  case Stage::MAKE_CALLS_UNIQUE: {
+    rewriter.setActiveTransformer("UniqueCallSiteTransformer");
+    UniqueCallTransformer uniqueCaller(rewriter, Ctx, usedFunsAndTypes);
+    uniqueCaller.transform();
+    break;
+  }
+  case Stage::DETERMINIZE: {
+    ExecutionCountAnalyzer execAnalyzer(Ctx, usedFunsAndTypes,
+                                        entryFunctionName);
+    // execAnalyzer.printFrequencies(llvm::outs()); // only for debugging
+    rewriter.setActiveTransformer("Determinizer");
+    Determinizer determinizer(rewriter, Ctx, execAnalyzer);
+    // the added inputs are reported in the facts sidecar
+    if (!factsFilename.empty()) {
+      state.facts.inputVariables = determinizer.addedInputVariables();
+      state.facts.inputArrays = determinizer.addedInputArrays();
+    }
+    break;
+  }
+  }
+}
+
+void MainConsumer::HandleTranslationUnit(clang::ASTContext& Ctx) {
+
+  // todo: process files where an error has occurred?
+  // errors also occur on some inputs which TriCera would accept
+  bool hadError = Ctx.getDiagnostics().hasErrorOccurred();
+  bool collectAllFuns = hadError || noDeclSlice;
+  bool collectAllTypes = hadError || noDeclSlice;
+
+  // collect all used functions and types
+  UsedFunAndTypeCollector usedFunsAndTypes(Ctx, collectAllFuns,
+                                           collectAllTypes);
+
+  // facts for the facts sidecar; if a round below rewrites the text, the
+  // driver collects them again from a parse of the final output
+  if (!factsFilename.empty())
+    collectFacts(Ctx, state.facts);
+
+  // run rounds on this parse until one rewrites something; the round
+  // after that needs a fresh parse of the rewritten text
+  size_t r = state.nextRound;
+  while (r < state.rounds.size()) {
+    size_t editsBefore = state.tracker.size();
+    const Round &round = state.rounds[r];
+    for (size_t i = 0; i < round.size(); ++i)
+      runStage(round[i], Ctx, usedFunsAndTypes, hadError);
+    if (state.tracker.size() != editsBefore && r + 1 < state.rounds.size())
+      break;
+    ++r;
+  }
+  state.executedThrough = r < state.rounds.size() ? r
+                                                  : state.rounds.size() - 1;
 
   preprocessOutput.usesArrays = 0;
   for (const Type* typ : usedFunsAndTypes.getSeenTypes()) {
@@ -90,30 +150,6 @@ void MainConsumer::HandleTranslationUnit(clang::ASTContext& Ctx) {
 
   // todo: set this to 1 if any unsupported features exist
   preprocessOutput.isUnsupported = 0;
-
-  // todo: any string to pass to output?
-  std::string s = "foo";
-  preprocessOutput.outputBuffer = new char[s.length()+1];
-  std::strcpy(preprocessOutput.outputBuffer, s.c_str());
-  delete[] preprocessOutput.outputBuffer;
-
-  //llvm::outs() << "--------------------------\n";
-  //llvm::outs() << "Seen functions:\n";
-  //llvm::outs() << "--------------------------\n";
-  //for (auto funInfo : usedFunsAndTypes.getSeenFunctions()) {
-  //  llvm::outs() << funInfo->getDecl()->getNameAsString();
-  //  if(funInfo->isRecursive())
-  //    llvm::outs() << " (recursive)";
-  //  llvm::outs() << "\n";
-  //}
-  //llvm::outs() << "--------------------------\n";
-  //llvm::outs() << "Seen types:\n";
-  //llvm::outs() << "--------------------------\n";
-  //for (const Type* typ : usedFunsAndTypes.getSeenTypes()) {
-  //  typ->dump();
-  //}
-  //rewriter.getEditBuffer(rewriter.getSourceMgr().getMainFileID())
-  //    .write(llvm::outs());
 }
 
 MainConsumer::~MainConsumer() {

--- a/lib/TriceraPreprocessor.cpp
+++ b/lib/TriceraPreprocessor.cpp
@@ -16,6 +16,7 @@
 #include "ExecutionCountAnalyzer.hpp"
 #include "NondetLoopGuardRewriter.hpp"
 #include "UniqueCallSiteTransformer.hpp"
+#include "CXXToCPlusTranslator.hpp"
 
 using namespace clang;
 using namespace ast_matchers;
@@ -33,6 +34,15 @@ void MainConsumer::runStage(Stage stage, clang::ASTContext &Ctx,
                             UsedFunAndTypeCollector &usedFunsAndTypes,
                             bool hadError) {
   switch (stage) {
+  case Stage::CXX_TO_CPLUS: {
+    // translate C++ to the C+ subset
+    if (!Ctx.getLangOpts().CPlusPlus)
+      break;
+    rewriter.setActiveTransformer("CXXToCPlusTranslator");
+    CXXToCPlusTranslator translator(Ctx, rewriter, state.facts.mangledNames);
+    translator.TraverseDecl(Ctx.getTranslationUnitDecl());
+    break;
+  }
   case Stage::TYPE_CANONISE: {
     // canonise all used types
     rewriter.setActiveTransformer("TypeCanoniser");
@@ -115,8 +125,10 @@ void MainConsumer::HandleTranslationUnit(clang::ASTContext& Ctx) {
   // todo: process files where an error has occurred?
   // errors also occur on some inputs which TriCera would accept
   bool hadError = Ctx.getDiagnostics().hasErrorOccurred();
-  bool collectAllFuns = hadError || noDeclSlice;
-  bool collectAllTypes = hadError || noDeclSlice;
+  // C++ slicing is not reliable yet, so keep all declarations for C++
+  bool isCXX = Ctx.getLangOpts().CPlusPlus;
+  bool collectAllFuns = hadError || noDeclSlice || isCXX;
+  bool collectAllTypes = hadError || noDeclSlice || isCXX;
 
   // collect all used functions and types
   UsedFunAndTypeCollector usedFunsAndTypes(Ctx, collectAllFuns,

--- a/lib/TypeCanoniser.cpp
+++ b/lib/TypeCanoniser.cpp
@@ -19,7 +19,7 @@ using namespace clang;
 using namespace ast_matchers;
 using namespace llvm;
 
-TypeCanoniserASTConsumer::TypeCanoniserASTConsumer(clang::Rewriter &r,
+TypeCanoniserASTConsumer::TypeCanoniserASTConsumer(TrackedRewriter &r,
                                   UsedFunAndTypeCollector &usedFunsAndTypes)
                            : rewriter(r) {
   handler = std::make_unique<TypeCanoniserMatcher>(rewriter, usedFunsAndTypes);
@@ -125,10 +125,22 @@ void TypeCanoniserMatcher::run(const MatchFinder::MatchResult &Result) {
         // this adds missing kind name if necessary, e.g. struct or union
         std::string tagName = (!isRecordWithKindName ? (kindName + " ") : "");
 
-        std::string completeTypeSpec = (tagName + 
+        std::string completeTypeSpec = (tagName +
                                         typeVisitor.getUnqualifiedTypeName());
 
         rewriter.ReplaceText(SourceRange(B, E), completeTypeSpec);
+
+        // name the anonymous record or enum, so the canonised uses refer
+        // to a declared tag once the typedef is removed
+        if (!isRecordWithKindName) {
+          const TagDecl *tagDecl = TheRecordType
+                                       ? TheRecordType->getAsTagDecl()
+                                       : TheEnumType->getAsTagDecl();
+          if (editedLocations.insert(tagDecl->getBeginLoc()).second)
+            rewriter.InsertTextAfterToken(
+                tagDecl->getBeginLoc(),
+                " " + TheTypedefType->getDecl()->getNameAsString());
+        }
       }
   } 
   else if (declStmt) {

--- a/lib/TypeCanoniser.cpp
+++ b/lib/TypeCanoniser.cpp
@@ -1,19 +1,12 @@
 #include "TypeCanoniser.hpp"
-#include "Utilities.hpp"
 
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
-#include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/TypeVisitor.h"
-
-#include "llvm/Support/raw_ostream.h"
-
 
 using namespace clang;
 using namespace ast_matchers;
@@ -27,43 +20,51 @@ TypeCanoniserASTConsumer::TypeCanoniserASTConsumer(TrackedRewriter &r,
     typedefType().bind("typedefType"), // matches nodes that use a typedef
     anyOf(
       //typeLoc(loc(qualType(typedefType(hasUnqualifiedDesugaredType(arrayType(hasElementType(qualType(hasDeclaration(decl(isImplicit()))))))))))
-      hasCanonicalType(recordType().bind("recordType")), 
-      hasCanonicalType(enumType().bind("enumType")), 
+      hasCanonicalType(recordType().bind("recordType")),
+      hasCanonicalType(enumType().bind("enumType")),
       // checking descendants looks through pointer types
       hasCanonicalType(hasDescendant(recordType().bind("recordType"))),
       hasCanonicalType(hasDescendant(enumType().bind("enumType"))),
       anything()
     )))).bind("typedefUsingTypeLoc");
-  
+
+  TypeLocMatcher unelaboratedTagLocMatcher = typeLoc(
+    loc(qualType(
+      anyOf(recordType().bind("directRecordType"), enumType().bind("directEnumType"))
+    ))
+  ).bind("unelaboratedTagLoc");
+
   // matches sizeof expressions such as int * x = malloc(sizeof * x);
-  // these are canonised as malloc(sizeof(int *))  
+  // these are canonised as malloc(sizeof(int *))
   StatementMatcher sizeOfMatcher = sizeOfExpr(unaryExprOrTypeTraitExpr(
     hasDescendant(declRefExpr().bind("sizeOfDeclRefExpr"))).bind("sizeOfExpr")
   );
 
   DeclarationMatcher enumMatcher = enumDecl().bind("enumDecl");
 
-  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource, 
+  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
     typedefUsingTypeLocMatcher), handler.get());
-  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource, 
+  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
+    unelaboratedTagLocMatcher), handler.get());
+  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
     sizeOfMatcher), handler.get());
-  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource, 
+  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
     enumMatcher), handler.get());
 }
 
 void TypeCanoniserASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
   finder.matchAST(Ctx);
-    
+
   StatementMatcher multiDeclStmtMatcher = declStmt(
-    unless(hasSingleDecl(decl())), 
-    containsDeclaration(0, 
+    unless(hasSingleDecl(decl())),
+    containsDeclaration(0,
       declaratorDecl(hasType(
         typedefType().bind("typedefType"))
       ).bind("declaratorDecl")
     )
   ).bind("declStmt");
 
-  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource, 
+  finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
     multiDeclStmtMatcher), handler.get());
   finder.matchAST(Ctx);
 }
@@ -73,77 +74,143 @@ void TypeCanoniserMatcher::run(const MatchFinder::MatchResult &Result) {
   ASTContext *Ctx = Result.Context;
 
   const TypeLoc* typedefUsingTypeLoc =
-    Result.Nodes.getNodeAs<clang::TypeLoc>("typedefUsingTypeLoc"); 
+    Result.Nodes.getNodeAs<clang::TypeLoc>("typedefUsingTypeLoc");
+  const TypeLoc* unelaboratedTagLoc =
+    Result.Nodes.getNodeAs<clang::TypeLoc>("unelaboratedTagLoc");
   const DeclStmt* declStmt =
-    Result.Nodes.getNodeAs<clang::DeclStmt>("declStmt"); 
+    Result.Nodes.getNodeAs<clang::DeclStmt>("declStmt");
   const TypedefType * TheTypedefType =
-    Result.Nodes.getNodeAs<clang::TypedefType>("typedefType"); 
+    Result.Nodes.getNodeAs<clang::TypedefType>("typedefType");
   const DeclRefExpr * sizeOfDeclRefExpr =
-    Result.Nodes.getNodeAs<clang::DeclRefExpr>("sizeOfDeclRefExpr"); 
+    Result.Nodes.getNodeAs<clang::DeclRefExpr>("sizeOfDeclRefExpr");
   const EnumDecl * enumDeclStmt =
-    Result.Nodes.getNodeAs<clang::EnumDecl>("enumDecl"); 
+    Result.Nodes.getNodeAs<clang::EnumDecl>("enumDecl");
 
-  if (typedefUsingTypeLoc) {       
-
-      const RecordType * TheRecordType = 
+  if (typedefUsingTypeLoc) {
+      const RecordType * TheRecordType =
           Result.Nodes.getNodeAs<clang::RecordType>("recordType");
-      const EnumType * TheEnumType = 
+      const EnumType * TheEnumType =
           Result.Nodes.getNodeAs<clang::EnumType>("enumType");
-      
+
       // return immediately if this is an unused record or enum type
       if (TheRecordType && !usedFunsAndTypes.typeIsSeen(TheRecordType) ||
-          TheEnumType && !usedFunsAndTypes.typeIsSeen(TheEnumType)) 
+          TheEnumType && !usedFunsAndTypes.typeIsSeen(TheEnumType))
         return;
 
       SourceLocation B = typedefUsingTypeLoc->getBeginLoc();
       SourceLocation E = typedefUsingTypeLoc->getEndLoc();
 
-      // T a, b; --> this generate two matches for two declarations: 
+      // T a, b; --> this generate two matches for two declarations:
       // once for both a and b. If we have replaced T once already,
       // we need to record it so we do not replace it again for b
       // however, if canon. T contained pointers, they should be prepended to b
-      if (editedLocations.insert(B).second) {  //second = T if inserted       
+      if (editedLocations.insert(B).second) {  //second = T if inserted
         auto canonicalType = // this does not get rid of some qualifiers
           QualType(TheTypedefType->getCanonicalTypeUnqualified());
 
         TypeCanoniserVisitor typeVisitor(*Ctx);
         typeVisitor.TraverseType(canonicalType); // gets rid of all qualifiers
 
-        bool isRecordWithKindName = true; // ignore if !TheRecordType
         std::string kindName = "";
-        if (TheRecordType || TheEnumType) {
-          if (TheRecordType) {
+        if (TheRecordType) {
             kindName = TheRecordType->getAsTagDecl()->getKindName().str();
-            isRecordWithKindName = !TheRecordType->getAsTagDecl()->getNameAsString().empty();
-          }
-          else {
+        } else if (TheEnumType) {
             kindName = "enum";
-            isRecordWithKindName = !TheEnumType->getAsTagDecl()->getNameAsString().empty();
-          }
         }
 
-        // this adds missing kind name if necessary, e.g. struct or union
-        std::string tagName = (!isRecordWithKindName ? (kindName + " ") : "");
+        std::string unqualName = typeVisitor.getUnqualifiedTypeName();
+        std::string tagName = "";
 
-        std::string completeTypeSpec = (tagName +
-                                        typeVisitor.getUnqualifiedTypeName());
+        if (!kindName.empty()) {
+            std::string expectedPrefix = kindName + " ";
+            if (unqualName.find(expectedPrefix) != 0) {
+                tagName = expectedPrefix;
+            }
+        }
 
+        std::string completeTypeSpec = tagName + unqualName;
         rewriter.ReplaceText(SourceRange(B, E), completeTypeSpec);
 
         // name the anonymous record or enum, so the canonised uses refer
         // to a declared tag once the typedef is removed
-        if (!isRecordWithKindName) {
-          const TagDecl *tagDecl = TheRecordType
-                                       ? TheRecordType->getAsTagDecl()
-                                       : TheEnumType->getAsTagDecl();
-          if (editedLocations.insert(tagDecl->getBeginLoc()).second)
-            rewriter.InsertTextAfterToken(
-                tagDecl->getBeginLoc(),
-                " " + TheTypedefType->getDecl()->getNameAsString());
+        const TagDecl *tagDecl = TheRecordType ? TheRecordType->getAsTagDecl()
+                               : TheEnumType ? TheEnumType->getAsTagDecl()
+                               : nullptr;
+        if (tagDecl && tagDecl->getNameAsString().empty() &&
+            editedLocations.insert(tagDecl->getBeginLoc()).second)
+          rewriter.InsertTextAfterToken(
+              tagDecl->getBeginLoc(),
+              " " + TheTypedefType->getDecl()->getNameAsString());
+      }
+  } else if (unelaboratedTagLoc) {
+    auto parents = Ctx->getParents(*unelaboratedTagLoc);
+    bool isWrapped = false;
+
+    SourceLocation insertLoc = unelaboratedTagLoc->getBeginLoc();
+
+    for (const auto& parent : parents) {
+      if (const TypeLoc* TL = parent.get<TypeLoc>()) {
+        if (auto ETL = TL->getAs<ElaboratedTypeLoc>()) { // already elaborated, skip
+          auto kw = ETL.getTypePtr()->getKeyword();
+          if (kw != ETK_None) {
+            isWrapped = true;
+          } else {
+            insertLoc = ETL.getBeginLoc();
+          }
+          break;
+        }
+      } else if (parent.get<CXXBaseSpecifier>() || // some cases where we do not want to elaborate, may not be exhaustive
+                 parent.get<CXXRecordDecl>() ||
+                 parent.get<NestedNameSpecifierLoc>() ||
+                 parent.get<NestedNameSpecifier>()) {
+          isWrapped = true;
+          break;
+      }
+    }
+
+    if (!isWrapped) {
+      // walk every ancestor chain, not just the first parent's
+      llvm::SmallVector<clang::DynTypedNode, 16> work(parents.begin(),
+                                                      parents.end());
+      unsigned steps = 0;
+      while (!work.empty() && !isWrapped && ++steps < 512) {
+        clang::DynTypedNode node = work.pop_back_val();
+        if (node.get<CXXThrowExpr>() ||
+            node.get<CXXDestructorDecl>() ||
+            node.get<CXXMemberCallExpr>()) {
+          isWrapped = true;
+          break;
+        }
+        auto nodeParents = Ctx->getParents(node);
+        work.append(nodeParents.begin(), nodeParents.end());
+      }
+    }
+
+    if (!isWrapped) { // need to elaborate the type
+      const RecordType* rt = Result.Nodes.getNodeAs<clang::RecordType>("directRecordType");
+      const EnumType* et = Result.Nodes.getNodeAs<clang::EnumType>("directEnumType");
+      TagDecl* tagDecl = nullptr;
+
+      if (rt) {
+        if (!usedFunsAndTypes.typeIsSeen(rt)) return;
+        tagDecl = rt->getDecl();
+      } else if (et) {
+        if (!usedFunsAndTypes.typeIsSeen(et)) return;
+        tagDecl = et->getDecl();
+      }
+
+      if (tagDecl && !tagDecl->getNameAsString().empty()) { // anonymous stuff
+        if (tagDecl->getLocation() == unelaboratedTagLoc->getBeginLoc()) return;
+
+        //SourceLocation B = unelaboratedTagLoc->getBeginLoc();
+
+        if (editedLocations.insert(insertLoc).second) {
+          std::string kindName = tagDecl->getKindName().str();
+          rewriter.InsertTextBefore(insertLoc, kindName + " ");
         }
       }
-  } 
-  else if (declStmt) {
+    }
+  } else if (declStmt) {
     // this matcher cannot match unless decl is DeclaratorDecl
     auto it = declStmt->decl_begin();
     const DeclaratorDecl* firstDecl = static_cast<DeclaratorDecl*>(*it);
@@ -153,7 +220,7 @@ void TypeCanoniserMatcher::run(const MatchFinder::MatchResult &Result) {
     for (; it != declStmt->decl_end(); ++it) {
       const DeclaratorDecl* decl = static_cast<DeclaratorDecl*>(*it);
       //decl->dumpColor();
-      auto canonicalType = 
+      auto canonicalType =
         QualType(TheTypedefType->getCanonicalTypeUnqualified());
       TypeCanoniserVisitor typeVisitor(*Ctx);
       typeVisitor.TraverseType(canonicalType);
@@ -190,7 +257,7 @@ void TypeCanoniserMatcher::run(const MatchFinder::MatchResult &Result) {
         rewriter.InsertTextAfterToken(lastDecl->getSourceRange().getEnd(),"/*");
         rewriter.InsertTextBefore(next_loc, "*/");
       }
-      
+
     }
   }
   else {
@@ -216,7 +283,7 @@ bool TypeCanoniserVisitor::VisitType(clang::Type *typ) {
         unqualTypeName = "(";
         bool start = true;
         for (auto paramType : paramTypes) {
-          unqualTypeName = unqualTypeName + 
+          unqualTypeName = unqualTypeName +
           ((!start ? ", " : "") + paramType.getAsString());
           if (start) start = false;
         }
@@ -225,7 +292,7 @@ bool TypeCanoniserVisitor::VisitType(clang::Type *typ) {
       }
       else {
         unqualType = QualType(typ, 0);
-        unqualTypeName = unqualType.getAsString();   
+        unqualTypeName = unqualType.getAsString();
       }
     }
     return true;

--- a/lib/TypedefRemover.cpp
+++ b/lib/TypedefRemover.cpp
@@ -19,7 +19,7 @@ using namespace clang;
 using namespace ast_matchers;
 using namespace llvm;
 
-TypedefRemoverASTConsumer::TypedefRemoverASTConsumer(clang::Rewriter &r,
+TypedefRemoverASTConsumer::TypedefRemoverASTConsumer(TrackedRewriter &r,
                                    UsedFunAndTypeCollector & usedFunsAndTypes):
                                     rewriter(r), handler(r, usedFunsAndTypes) {
   DeclarationMatcher typedefDeclMatcher = anyOf(
@@ -140,29 +140,22 @@ void TypedefMatcher::run(const MatchFinder::MatchResult &Result) {
     if (TheRecordType) declName = TheRecordType->getDecl()->getNameAsString();
     else if (TheEnumType) declName = TheEnumType->getDecl()->getNameAsString();
     else llvm_unreachable("");
-    // comment out / remove the typedef keyword and
-    // end the comment right before record declaration starts
-    wrapWithCComment(SourceRange(TypeDefBeginLoc, RecordDeclBeginLoc),
-                     rewriter);
+    // remove the typedef keyword up to where the record declaration starts
+    rewriter.BlankChars(TypeDefBeginLoc, RecordDeclBeginLoc);
 
-    // comment out / remove the typedef names right after the record
-    // end the comment right before the semicolon
-    wrapWithCComment(SourceRange(
-      RecordDeclEndLoc, TypeDefEndLoc.getLocWithOffset(-1)),
-                     rewriter, false);
+    // remove the typedef names between the record declaration and the
+    // semicolon
+    rewriter.BlankChars(
+      Lexer::getLocForEndOfToken(RecordDeclEndLoc, 0, Ctx->getSourceManager(),
+                                 Ctx->getLangOpts()),
+      TypeDefEndLoc.getLocWithOffset(-1));
 
     // copies x in "typedef struct {} x" to right after "struct" if missing
     if(declName.empty())
       rewriter.InsertTextAfterToken(RecordDeclBeginLoc,
         (" " + TheTypedefDecl->getNameAsString()));
   } else { // if typedef does not contain a record declaration
-    // comment it out (or alternatively remove it)
-    //llvm::outs()<<"commenting out decl\n";
-    //lastDecl->dump();
-    doubleSlashCommentOutDeclaration(lastDecl, *Ctx, rewriter);
-
-    //rewriter.InsertTextBefore(TypeDefBeginLoc, "/* ");
-    //rewriter.InsertTextAfterToken(TypeDefEndLoc, " */");
-    //rewriter.RemoveText(SourceRange(TypeDefBeginLoc,TypeDefEndLoc.getLocWithOffset(-1)));
+    // remove it
+    blankOutDeclaration(lastDecl, *Ctx, rewriter);
   }
 }

--- a/lib/UniqueCallSiteTransformer.cpp
+++ b/lib/UniqueCallSiteTransformer.cpp
@@ -53,7 +53,7 @@ static bool isLeafFunction(const FunctionDecl *FD) {
 }
 
 UniqueCallTransformer::UniqueCallTransformer(
-    clang::Rewriter &R, clang::ASTContext &Ctx, const UsedFunAndTypeCollector &U)
+    TrackedRewriter &R, clang::ASTContext &Ctx, const UsedFunAndTypeCollector &U)
     : rewriter(R), Ctx(Ctx), usedFunsAndTypes(U) {}
 
 void UniqueCallTransformer::transform() {
@@ -203,7 +203,21 @@ std::string UniqueCallTransformer::getOrCreateClone(const FunctionDecl *FD) {
       insertPos = clang::Lexer::getLocForEndOfToken(mostRecentDecl->getEndLoc(), 0, SM, LangOpts);
   }
 
-  rewriter.InsertText(insertPos, "\n\n" + originalFuncText);
+  // record where the cloned text came from, so line markers can map the
+  // clone back to the original declaration. the inserted text starts with
+  // "\n\n", giving one empty line before the cloned text, so the origin is
+  // one line above the declaration.
+  unsigned originLine = 0;
+  std::pair<clang::FileID, unsigned> cloneBegin =
+      SM.getDecomposedLoc(rangeToCopy.getBegin());
+  if (cloneBegin.first == SM.getMainFileID()) {
+    unsigned line = SM.getLineNumber(cloneBegin.first, cloneBegin.second);
+    if (line > 1)
+      originLine = line - 1;
+  }
+  rewriter.InsertText(insertPos, "\n\n" + originalFuncText,
+                      /*InsertAfter=*/true, /*indentNewLines=*/false,
+                      originLine);
 
   return newName;
 }

--- a/lib/UnusedDeclCommenter.cpp
+++ b/lib/UnusedDeclCommenter.cpp
@@ -19,13 +19,13 @@ using namespace clang;
 using namespace ast_matchers;
 using namespace llvm;
 
-UnusedDeclCommenter::UnusedDeclCommenter(clang::Rewriter &r, clang::ASTContext &Ctx, 
+UnusedDeclCommenter::UnusedDeclCommenter(TrackedRewriter &r, clang::ASTContext &Ctx, 
                       UsedFunAndTypeCollector &usedFunsAndTypes) {
     UnusedDeclCommenterASTConsumer c(r, usedFunsAndTypes);
     c.HandleTranslationUnit(Ctx);
 }
 
-UnusedDeclCommenterASTConsumer::UnusedDeclCommenterASTConsumer(clang::Rewriter &r,
+UnusedDeclCommenterASTConsumer::UnusedDeclCommenterASTConsumer(TrackedRewriter &r,
                                      UsedFunAndTypeCollector &usedFunsAndTypes)
                            : rewriter(r) {
   handler = std::make_unique<UnusedDeclCommenterMatcher>(rewriter, usedFunsAndTypes);
@@ -33,10 +33,11 @@ UnusedDeclCommenterASTConsumer::UnusedDeclCommenterASTConsumer(clang::Rewriter &
   anyOf(
     // comment out unused function decls
     functionDecl(unless(isImplicit())).bind("functionDecl"), 
-    // comment out unused record decls
-    recordDecl().bind("recordDecl"), 
-    // comment out unused enum decls
-    enumDecl().bind("enumDecl"),
+    // remove unused record decls; those inside a typedef belong to the
+    // TypedefRemover
+    recordDecl(unless(hasAncestor(typedefDecl()))).bind("recordDecl"),
+    // remove unused enum decls
+    enumDecl(unless(hasAncestor(typedefDecl()))).bind("enumDecl"),
     // comment out var decls using records,
     varDecl(
       unless(parmVarDecl()), // unless they are fun args
@@ -69,31 +70,31 @@ void UnusedDeclCommenterMatcher::run(const MatchFinder::MatchResult &Result) {
     Result.Nodes.getNodeAs<clang::EnumDecl>("enumDecl");
 
   if (functionDecl) 
-  { // comment out unused function declarations
+  { // remove unused function declarations
     if (!usedFunsAndTypes.functionIsSeen(functionDecl))
-      doubleSlashCommentOutDeclaration(functionDecl, *Ctx, rewriter);
+      blankOutDeclaration(functionDecl, *Ctx, rewriter);
   } 
   else if (recordDecl) 
-  { // comment out unused record declarations
+  { // remove unused record declarations
     if (!usedFunsAndTypes.typeIsSeen(
         Ctx->getTypeDeclType(recordDecl).getTypePtr()))
-      doubleSlashCommentOutDeclaration(recordDecl, *Ctx, rewriter);
+      blankOutDeclaration(recordDecl, *Ctx, rewriter);
   }
   else if (enumDecl)
-  { // comment out unused enum declarations
+  { // remove unused enum declarations
     if (!usedFunsAndTypes.typeIsSeen(
         Ctx->getTypeDeclType(enumDecl).getTypePtr()))
-      doubleSlashCommentOutDeclaration(enumDecl, *Ctx, rewriter);
+      blankOutDeclaration(enumDecl, *Ctx, rewriter);
   }
   else if (varDecl) 
-  { // comment out unused var declarations
-    // note that this might comment out some record declarations
+  { // remove unused var declarations
+    // note that this might blank out some record declarations
     // several times if the vars are declared as part of the
     // record declaration: e.g. struct s {...} s1;
     const QualType * varBaseType =
       Result.Nodes.getNodeAs<clang::QualType>("varBaseType"); 
     if (!usedFunsAndTypes.typeIsSeen(varBaseType))
-      doubleSlashCommentOutDeclaration(varDecl, *Ctx, rewriter);
+      blankOutDeclaration(varDecl, *Ctx, rewriter);
   }
   else {
     llvm_unreachable("UnusedDeclCommenter unreachable case\n");

--- a/lib/UsedFunctionAndTypeCollector.cpp
+++ b/lib/UsedFunctionAndTypeCollector.cpp
@@ -40,9 +40,12 @@ void handleFunDecl(const clang::FunctionDecl* funDecl,
   
   StatementMatcher CallSiteOrDeclRefMatcher = anyOf(
   callExpr(
-    hasAncestor(functionDecl(hasName(funDecl->getName())).bind("enclosing")),
+    hasAncestor(functionDecl(hasName(funDecl->getNameAsString())).bind("enclosing")),
     callee(functionDecl().bind("callee"))).bind("caller"),
-    declRefExpr(allOf(hasAncestor(functionDecl(hasName(funDecl->getName())).bind("enclosing")),
+  cxxMemberCallExpr(
+    hasAncestor(functionDecl(hasName(funDecl->getNameAsString())).bind("enclosing")),
+    callee(cxxMethodDecl().bind("callee"))).bind("caller"),
+    declRefExpr(allOf(hasAncestor(functionDecl(hasName(funDecl->getNameAsString())).bind("enclosing")),
     anyOf(
        allOf(
          unless(anyOf(hasType(functionProtoType()),
@@ -60,7 +63,8 @@ void handleFunDecl(const clang::FunctionDecl* funDecl,
   TypeLocMatcher usedTypesMatcher = typeLoc(
     loc(qualType().bind("usedType")), 
     hasAncestor(expr()), // this ensures that the type is used in an expr.
-    hasAncestor(functionDecl(hasName(funDecl->getName())))).bind("usedTypeLoc");
+    hasAncestor(functionDecl(hasName(funDecl->getNameAsString())))
+  ).bind("usedTypeLoc");
 
   clang::ast_matchers::MatchFinder finder;
   finder.addMatcher(traverse(TK_IgnoreUnlessSpelledInSource, CallSiteOrDeclRefMatcher), handler);
@@ -153,10 +157,10 @@ void FindFunctionMatcher::run(const MatchFinder::MatchResult &Result) {
   } else if (CalleeDecl) { // matched a CallExpr
     //llvm::outs() << EnclosingDecl->getNameAsString() << "\n";
    
-    assert(declaresSameEntity(TheCall->getDirectCallee(), CalleeDecl));
+    assert(TheCall->getDirectCallee() == nullptr || declaresSameEntity(TheCall->getDirectCallee(), CalleeDecl));
 
-    // todo: maybe detect mutually recursive funs, or recursion afterseveral steps
-    bool functionIsRecursive = declaresSameEntity(CalleeDecl, EnclosingDecl);
+    // todo: maybe detect mutually recursive funs, or recursion after several steps
+    bool functionIsRecursive = (EnclosingDecl && declaresSameEntity(CalleeDecl, EnclosingDecl));
     
     bool functionSeenBefore = false;
     if (std::find(ignoredFuns.begin(), ignoredFuns.end(), 

--- a/lib/Utilites.cpp
+++ b/lib/Utilites.cpp
@@ -7,13 +7,9 @@
 #include "clang/Lex/Lexer.h"
 #include "clang/AST/PrettyPrinter.h"
 
-// todo: does not take into account possible declarations in the same line
-// maybe switch to C-style /*...*/ comments in that case?
-// another option might be to insert a new line after each declaration,
-// but this would change line numbers
-bool doubleSlashCommentOutDeclaration (const clang::Decl* declaration,
-                                       clang::ASTContext &ctx,
-                                       clang::Rewriter& rewriter) {
+bool blankOutDeclaration (const clang::Decl* declaration,
+                          clang::ASTContext &ctx,
+                          TrackedRewriter& rewriter) {
     clang::SourceManager &SM = ctx.getSourceManager();
 
     clang::FullSourceLoc B_full = ctx.getFullLoc(declaration->getBeginLoc());
@@ -22,9 +18,13 @@ bool doubleSlashCommentOutDeclaration (const clang::Decl* declaration,
     // return if this declaration is not in the main file
     if (B_full.isInvalid() || B_full.getFileID() != SM.getMainFileID())
         return false;
+    if (E_full.isInvalid())
+        return false;
 
+    clang::SourceLocation beginLoc = declaration->getBeginLoc();
+
+    // cover a stand-alone __extension__ on the preceding line
     unsigned int startLineNum = B_full.getLineNumber();
-
     if (startLineNum > 1) {
         unsigned int prevLineNum = startLineNum - 1;
 
@@ -36,31 +36,19 @@ bool doubleSlashCommentOutDeclaration (const clang::Decl* declaration,
             llvm::StringRef prevLineText = restOfFile.substr(0, restOfFile.find_first_of("\r\n"));
 
             if (prevLineText.trim() == "__extension__") {
-                startLineNum = prevLineNum;
+                beginLoc = prevLineStartLoc;
             }
         }
     }
 
-    for (unsigned i = startLineNum; i <= E_full.getLineNumber(); ++i) {
-        clang::SourceLocation lineStart = SM.translateLineCol(SM.getMainFileID(), i, 1);
-        if(lineStart.isInvalid()) continue;
-        rewriter.InsertText(lineStart, "// ");
-    }
-    return true;
-}
-
-void wrapWithCComment (clang::SourceRange sourceRange,
-                       clang::Rewriter& rewriter,
-                       bool insertBeforeBegin,
-                       bool insertBeforeEnd){
-  if(insertBeforeBegin)
-    rewriter.InsertTextBefore(sourceRange.getBegin(), "/* ");
-  else
-    rewriter.InsertTextAfterToken(sourceRange.getBegin(), "/* ");
-  if(insertBeforeEnd)
-    rewriter.InsertTextBefore(sourceRange.getEnd(), " */ ");
-  else
-    rewriter.InsertTextAfterToken(sourceRange.getEnd(), " */ ");
+    // cover the trailing semicolon if there is one
+    clang::SourceLocation afterSemiLoc = clang::Lexer::findLocationAfterToken(
+        declaration->getEndLoc(), clang::tok::semi, SM, ctx.getLangOpts(),
+        /*SkipTrailingWhitespaceAndNewLine=*/false);
+    if (afterSemiLoc.isValid())
+        return !rewriter.BlankChars(beginLoc, afterSemiLoc);
+    return !rewriter.BlankText(clang::SourceRange(beginLoc,
+                                                  declaration->getEndLoc()));
 }
 
 bool BaseTypeExtractor::VisitType(clang::Type *typ) {

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,32 @@ which should print out the preprocessed file.
 # Implementation
 Read on if you are interested in the implementation.
 
-tri-pp has several components which are called sequentially.
+tri-pp runs its transformers in rounds, one transformer per round. Each
+round runs on a fresh parse of the previous round's text (held in memory),
+so the transformers cannot conflict: every round sees the earlier work as
+plain source text. A round that rewrites nothing reuses its parse for the
+next round, so the extra parses cost little. All edits are still tracked,
+and edits whose combined effect depends on application order (a bug within
+a single transformer) are reported loudly, with exit code 4, instead of
+being composed silently.
+
+Removed source text (typedefs, unused declarations, extracted for-loop
+declarations, ...) is replaced by whitespace of identical geometry: newlines
+are kept and every other character becomes a space. Byte offsets and line
+numbers of the surrounding code therefore stay stable.
+
+With `--line-markers`, the produced file carries GNU linemarkers
+(`# <line> "<file>"`) wherever the line mapping between input and output
+jumps, so a consumer can map every output line back to an authentic line of
+the original input. Inputs that already contain linemarkers (from cpp, or
+from an earlier tri-pp stage; TriCera invokes tri-pp up to three times in a
+row) are consumed and re-emitted in the original coordinates. An input that
+tri-pp does not rewrite is passed through unchanged.
+
+With `--facts <path>`, a small YAML file is written next to the output
+stating facts about the produced program.
+
+The transformer components:
 
 ## UsedFunctionAndTypeCollector
 It tries to find the main function, and follows all function calls from main
@@ -40,7 +65,7 @@ E.g. `typedef struct {...} S;` is converted to `struct S {...};`.
 Removes all unused declarations, which include both function and type
 declarations. It uses the results from "UsedFunctionAndTypeCollector".
 
-This also comments out some function declarations (or their implementations) 
+This also removes some function declarations (or their implementations)
 coming from included libraries, which are handled by TriCera natively. Examples
 are `__assert_fail`, `__assert_perror_fail`, `__assert` or SV-COMP functions
 such as `reach_error` (https://sv-comp.sosy-lab.org/2021/benchmarks.php).
@@ -59,20 +84,6 @@ Moves declarations from inside the for loop declaration to outside. E.g.,
 TriCera cannot parse the former directly.
 
 # Known Issues
-- UnusedDeclCommenter will comment out whole lines that the declaration is in. If
-  another declaration is in the same line, it will also be commented out. This
-  should usually not be an issue if the other declarations are using the same base
-  type, because UnusedDeclCommenter only comments out a declaration (except
-  function declarations) if the type of that declaration is never seen in the
-  program.
-
-  E.g. For `T1 x; T2 y;`, if either T1 or T2 is not a seen type, both declarations
-  will be commented out since they are in the same line.
-
-- TypedefRemover comments out some parts of the record declarations using
-  C-style `/*...*/` comments. If the commented-out region has nested comments
-  this might lead to unparseable output.
-  
 - Preprocessor might not always work correctly when using non-standard C that
   TriCera accepts. E.g. `thread {...}` blocks are not parsed correctly by the
   preprocessor, so TypeCanoniser does not work inside these blocks (i.e., use

--- a/tests/cpp_support/Answers
+++ b/tests/cpp_support/Answers
@@ -1,0 +1,429 @@
+
+--- inheritance_multiple.cpp ---
+class Drawable {
+public:
+    virtual void draw() = 0;
+};
+
+class Clickable {
+public:
+    virtual void onClick() {}
+};
+
+class Button : public Drawable, public Clickable {
+public:
+    void draw() override {}
+    void onClick() override {}
+    static int getClickCount() { return count; }
+private:
+    static int count;
+};
+
+int Button::count = 0;
+
+int main() {
+    class Button b;
+    b.draw();
+    b.onClick();
+    return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- namespaces_nested.cpp ---
+namespace university {
+    namespace department {
+        class Teacher {
+        public:
+            struct Details {
+                int age;
+                char* name;
+            };
+            void setDetails(struct Details d) { this->info = d; }
+            struct Details getDetails() const { return this->info; }
+        private:
+            struct university::department::Teacher::Details info;
+        };
+    }
+}
+
+int main() {
+    class university::department::Teacher t;
+    struct university::department::Teacher::Details d;
+    t.university::department::Teacher::setDetails(d);
+    return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- templates_basic.cpp ---
+class Box_double_ {
+public:
+  Box_double_(double val) : value(val) {
+}
+  double getValue() const {
+    return this->value;
+}
+  void setValue(double val) {
+    this->value = val;
+}
+private:
+  double value;
+};
+
+
+class Box_int_ {
+public:
+  Box_int_(int val) : value(val) {
+}
+  int getValue() const {
+    return this->value;
+}
+  void setValue(int val) {
+    this->value = val;
+}
+private:
+  int value;
+};
+
+
+                     
+           
+       
+                              
+                                        
+                                         
+        
+            
+ ;
+
+class Base {
+public:
+    virtual void show() {}
+};
+
+class Derived : public Base {
+public:
+    void show() override {}
+    static int getKind() { return 1; }
+};
+
+int main() {
+    class Box_int_ intBox(10);
+    class Box_double_ doubleBox(20.5);
+    class Derived d;
+    return 0;
+}
+--- mangledNames ---
+mangledNames:
+  - mangled: Box_int_
+    original: "Box<int>"
+  - mangled: Box_double_
+    original: "Box<double>"
+
+--- templates_complex.cpp ---
+class Pair_int__char_ {
+public:
+  int first;
+  char second;
+  Pair_int__char_(int a, char b) : first(a), second(b) {
+}
+};
+
+
+                                   
+            
+       
+             
+              
+                                             
+ ;
+
+                     
+                 
+                 
+ 
+
+int add_int_(int a, int b) {
+    return a + b;
+}
+
+
+
+double add_double_(double a, double b) {
+    return a + b;
+}
+
+
+
+int main() {
+    class Pair_int__char_ p(1, 97);
+    int sum = add_int_(5, 10);
+    double dsum = add_double_(1.5, 2.5);
+    return 0;
+}
+--- mangledNames ---
+mangledNames:
+  - mangled: Pair_int__char_
+    original: "Pair<int, char>"
+  - mangled: add_int_
+    original: "add<int>"
+  - mangled: add_double_
+    original: "add<double>"
+
+--- templates_typedef.cpp ---
+class Box_char_ {
+public:
+  Box_char_(char val) : value(val) {
+}
+  char getValue() const {
+    return this->value;
+}
+private:
+  char value;
+};
+
+
+class Box_double_ {
+public:
+  Box_double_(double val) : value(val) {
+}
+  double getValue() const {
+    return this->value;
+}
+private:
+  double value;
+};
+
+
+class Box_int_ {
+public:
+  Box_int_(int val) : value(val) {
+}
+  int getValue() const {
+    return this->value;
+}
+private:
+  int value;
+};
+
+
+                     
+           
+       
+                              
+                                        
+        
+            
+ ;
+
+                              
+using DoubleBox = class Box_double_;
+
+int main() {
+    class Box_int_ ib(10);
+    class Box_double_ db(20.5);
+    class Box_char_ cb(97);
+    
+    int v = ib.Box_int_::getValue();
+    double d = db.Box_double_::getValue();
+    
+    return 0;
+}
+--- mangledNames ---
+mangledNames:
+  - mangled: Box_int_
+    original: "Box<int>"
+  - mangled: Box_double_
+    original: "Box<double>"
+  - mangled: Box_char_
+    original: "Box<char>"
+
+--- elab_type_simple.cpp ---
+class C {
+    int x;
+};
+
+int main() {
+    class C c1;
+    class C *c2 = &c1;
+    class C &c3 = c1;
+    class C **c4 = &c2;
+
+    class C c5, *c6;
+
+    return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- elab_type_nested_classes.cpp ---
+class Outermost {
+  public:
+    class Inner {
+      public:
+        class Innermost {
+        };
+    };
+};
+
+
+int main() {
+  class Outermost x;
+  class Outermost::Inner y;
+  class Outermost::Inner::Innermost z;
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- access_member_vars.cpp ---
+class C {
+  public:
+    int val;
+
+    void set(int value) {
+      this->val = value;
+    }
+
+    void shadowed_set(int val) {
+      val = val;
+    }
+
+    void qualified_set(int val) {
+      this->val = val;
+    }
+};
+
+int main() {
+  class C c;
+  c.C::set(5);
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- throw_test.cpp ---
+class MyException {};
+
+void f() {
+  throw (class MyException) (MyException());
+}
+
+void g(int x) {
+  if (x > 0) throw (int) (x);
+  if (x < 0) throw (const char *) ("error");
+  throw (double) (1.0 + 2.0);
+}
+
+struct S {
+    int a;
+};
+
+void h() {
+    struct S s = {1};
+    throw (struct S) (s);
+}
+
+void i() {
+    throw (char) (97);
+}
+
+int main() {
+  try {
+    f();
+  } catch (class MyException& e) {
+  }
+  try {
+    g(1);
+  } catch (...) {}
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- throw_with_cast.cpp ---
+class MyException {};
+
+void f() {
+  // Existing elaborated cast
+  throw (class MyException) ((class MyException) MyException());
+}
+
+void g() {
+  // Existing unelaborated cast
+  throw (class MyException) ((MyException) MyException());
+}
+
+struct S { int a; };
+
+void h() {
+  // Existing struct cast
+  throw (struct S) ((struct S) S{1});
+}
+
+int main() {
+  try { f(); } catch (...) {}
+  try { g(); } catch (...) {}
+  try { h(); } catch (...) {}
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []
+
+--- qualified_function_calls.cpp ---
+class A {
+  public:
+    int x;
+    void set(int val) {
+      this->x = val;
+    }
+    int get() {
+      return this->x;
+    }
+
+    virtual int num() {
+      return 1;
+    }
+};
+class B : public A {
+  public:
+    int y;
+    int num() override {
+      return 2;
+    }
+};
+
+
+class C {
+  public:
+    int x;
+    C(int val) {
+      this->x = val;
+    }
+
+    ~C() {}
+};
+
+class Unused {
+};
+
+int main() {
+  class A a;
+  a.A::set(1);
+  a.A::get();
+
+  class B b;
+  class A *a_ptr = &b;
+
+  a_ptr->num(); // Should not be qualified as it is dynamically dispatched
+  b.num(); // Should not be qualified, still goes via vtable
+
+  class C c(10);
+
+  c.C::~C();
+
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []

--- a/tests/cpp_support/access_member_vars.cpp
+++ b/tests/cpp_support/access_member_vars.cpp
@@ -1,0 +1,22 @@
+class C {
+  public:
+    int val;
+
+    void set(int value) {
+      val = value;
+    }
+
+    void shadowed_set(int val) {
+      val = val;
+    }
+
+    void qualified_set(int val) {
+      this->val = val;
+    }
+};
+
+int main() {
+  C c;
+  c.set(5);
+  return 0;
+}

--- a/tests/cpp_support/elab_type_nested_classes.cpp
+++ b/tests/cpp_support/elab_type_nested_classes.cpp
@@ -1,0 +1,16 @@
+class Outermost {
+  public:
+    class Inner {
+      public:
+        class Innermost {
+        };
+    };
+};
+
+
+int main() {
+  Outermost x;
+  Outermost::Inner y;
+  Outermost::Inner::Innermost z;
+  return 0;
+}

--- a/tests/cpp_support/elab_type_simple.cpp
+++ b/tests/cpp_support/elab_type_simple.cpp
@@ -1,0 +1,14 @@
+class C {
+    int x;
+};
+
+int main() {
+    C c1;
+    C *c2 = &c1;
+    C &c3 = c1;
+    C **c4 = &c2;
+
+    C c5, *c6;
+
+    return 0;
+}

--- a/tests/cpp_support/inheritance_multiple.cpp
+++ b/tests/cpp_support/inheritance_multiple.cpp
@@ -1,0 +1,27 @@
+class Drawable {
+public:
+    virtual void draw() = 0;
+};
+
+class Clickable {
+public:
+    virtual void onClick() {}
+};
+
+class Button : public Drawable, public Clickable {
+public:
+    void draw() override {}
+    void onClick() override {}
+    static int getClickCount() { return count; }
+private:
+    static int count;
+};
+
+int Button::count = 0;
+
+int main() {
+    Button b;
+    b.draw();
+    b.onClick();
+    return 0;
+}

--- a/tests/cpp_support/namespaces_nested.cpp
+++ b/tests/cpp_support/namespaces_nested.cpp
@@ -1,0 +1,22 @@
+namespace university {
+    namespace department {
+        class Teacher {
+        public:
+            struct Details {
+                int age;
+                char* name;
+            };
+            void setDetails(Details d) { info = d; }
+            Details getDetails() const { return info; }
+        private:
+            Details info;
+        };
+    }
+}
+
+int main() {
+    university::department::Teacher t;
+    university::department::Teacher::Details d;
+    t.setDetails(d);
+    return 0;
+}

--- a/tests/cpp_support/qualified_function_calls.cpp
+++ b/tests/cpp_support/qualified_function_calls.cpp
@@ -1,0 +1,53 @@
+class A {
+  public:
+    int x;
+    void set(int val) {
+      x = val;
+    }
+    int get() {
+      return x;
+    }
+
+    virtual int num() {
+      return 1;
+    }
+};
+class B : public A {
+  public:
+    int y;
+    int num() override {
+      return 2;
+    }
+};
+
+
+class C {
+  public:
+    int x;
+    C(int val) {
+      x = val;
+    }
+
+    ~C() {}
+};
+
+class Unused {
+};
+
+int main() {
+  A a;
+  a.set(1);
+  a.get();
+
+  B b;
+  A *a_ptr = &b;
+
+  a_ptr->num(); // Should not be qualified as it is dynamically dispatched
+  b.num(); // Should not be qualified, still goes via vtable
+
+  C c(10);
+
+  c.C::~C();
+
+  return 0;
+}

--- a/tests/cpp_support/runtests
+++ b/tests/cpp_support/runtests
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# C++ lowering: templates are monomorphised, their uses replaced by mangled
+# names, member accesses qualified, throw operands cast. The mangled-name
+# map goes into the facts sidecar. Each test dumps the preprocessed output
+# and the mangledNames section of the facts file.
+
+TESTS="inheritance_multiple.cpp \
+       namespaces_nested.cpp \
+       templates_basic.cpp \
+       templates_complex.cpp \
+       templates_typedef.cpp \
+       elab_type_simple.cpp \
+       elab_type_nested_classes.cpp \
+       access_member_vars.cpp \
+       throw_test.cpp \
+       throw_with_cast.cpp \
+       qualified_function_calls.cpp"
+
+for name in $TESTS; do
+    echo
+    echo "--- $name ---"
+    FACTS_TMP=$(mktemp)
+    $TRI_CMD "$@" --facts "$FACTS_TMP" "$name" -- -xc++ 2>&1
+    echo "--- mangledNames ---"
+    sed -n '/^mangledNames:/,$p' "$FACTS_TMP"
+    rm -f "$FACTS_TMP"
+done

--- a/tests/cpp_support/templates_basic.cpp
+++ b/tests/cpp_support/templates_basic.cpp
@@ -1,0 +1,27 @@
+template <typename T>
+class Box {
+public:
+    Box(T val) : value(val) {}
+    T getValue() const { return value; }
+    void setValue(T val) { value = val; }
+private:
+    T value;
+};
+
+class Base {
+public:
+    virtual void show() {}
+};
+
+class Derived : public Base {
+public:
+    void show() override {}
+    static int getKind() { return 1; }
+};
+
+int main() {
+    Box<int> intBox(10);
+    Box<double> doubleBox(20.5);
+    Derived d;
+    return 0;
+}

--- a/tests/cpp_support/templates_complex.cpp
+++ b/tests/cpp_support/templates_complex.cpp
@@ -1,0 +1,19 @@
+template <typename T1, typename T2>
+class Pair {
+public:
+    T1 first;
+    T2 second;
+    Pair(T1 a, T2 b) : first(a), second(b) {}
+};
+
+template <typename T>
+T add(T a, T b) {
+    return a + b;
+}
+
+int main() {
+    Pair<int, char> p(1, 'a');
+    int sum = add<int>(5, 10);
+    double dsum = add(1.5, 2.5);
+    return 0;
+}

--- a/tests/cpp_support/templates_typedef.cpp
+++ b/tests/cpp_support/templates_typedef.cpp
@@ -1,0 +1,22 @@
+template <typename T>
+class Box {
+public:
+    Box(T val) : value(val) {}
+    T getValue() const { return value; }
+private:
+    T value;
+};
+
+typedef Box<int> IntBox;
+using DoubleBox = Box<double>;
+
+int main() {
+    IntBox ib(10);
+    DoubleBox db(20.5);
+    Box<char> cb('a');
+    
+    int v = ib.getValue();
+    double d = db.getValue();
+    
+    return 0;
+}

--- a/tests/cpp_support/throw_test.cpp
+++ b/tests/cpp_support/throw_test.cpp
@@ -1,0 +1,35 @@
+class MyException {};
+
+void f() {
+  throw MyException();
+}
+
+void g(int x) {
+  if (x > 0) throw x;
+  if (x < 0) throw "error";
+  throw 1.0 + 2.0;
+}
+
+struct S {
+    int a;
+};
+
+void h() {
+    S s = {1};
+    throw s;
+}
+
+void i() {
+    throw 'a';
+}
+
+int main() {
+  try {
+    f();
+  } catch (MyException& e) {
+  }
+  try {
+    g(1);
+  } catch (...) {}
+  return 0;
+}

--- a/tests/cpp_support/throw_with_cast.cpp
+++ b/tests/cpp_support/throw_with_cast.cpp
@@ -1,0 +1,25 @@
+class MyException {};
+
+void f() {
+  // Existing elaborated cast
+  throw (class MyException) MyException();
+}
+
+void g() {
+  // Existing unelaborated cast
+  throw (MyException) MyException();
+}
+
+struct S { int a; };
+
+void h() {
+  // Existing struct cast
+  throw (struct S) S{1};
+}
+
+int main() {
+  try { f(); } catch (...) {}
+  try { g(); } catch (...) {}
+  try { h(); } catch (...) {}
+  return 0;
+}

--- a/tests/facts/Answers
+++ b/tests/facts/Answers
@@ -8,10 +8,13 @@ allocationFunctions: [free, malloc]
 # declarations with array types / with arrays of unknown bound
 usesArrays: false
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -24,10 +27,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: false
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -40,10 +46,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: false
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -56,10 +65,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: true
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -72,10 +84,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: true
 usesUnboundedArrays: true
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -88,10 +103,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: false
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: [IN1_g]
 inputArrays: [IN_ARR_2_g]
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -104,10 +122,13 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: true
 usesUnboundedArrays: true
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: [IN1_g]
 inputArrays: [IN_ARR_2_g]
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
 
@@ -120,9 +141,31 @@ allocationFunctions: []
 # declarations with array types / with arrays of unknown bound
 usesArrays: false
 usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: false
+usesTryCatch: false
 # inputs added by the determinizer (also in the INPUT header comment)
 inputVariables: []
 inputArrays: []
-# approximate: token-level scan for TriCera's clock/duration extensions
+# clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: true
+durationTokenSeen: false
+
+exceptions.cpp
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# C++ exceptions
+usesThrow: true
+usesTryCatch: true
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# clock/duration are TriCera keywords; reported when the token appears
+clockTokenSeen: false
 durationTokenSeen: false

--- a/tests/facts/Answers
+++ b/tests/facts/Answers
@@ -17,6 +17,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 nothing_referenced.c
 exit code: 0
@@ -36,6 +38,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 malloc_in_removed_decl.c
 exit code: 0
@@ -55,6 +59,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 sized_array.c
 exit code: 0
@@ -74,6 +80,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 unbounded_array_param.c
 exit code: 0
@@ -93,6 +101,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 determinize_adds_arrays.c
 exit code: 0
@@ -112,6 +122,8 @@ inputArrays: [IN_ARR_2_g]
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 determinize_with_own_arrays.c
 exit code: 0
@@ -131,6 +143,8 @@ inputArrays: [IN_ARR_2_g]
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 time_tokens.c
 exit code: 0
@@ -150,6 +164,8 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: true
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []
 
 exceptions.cpp
 exit code: 0
@@ -169,3 +185,5 @@ inputArrays: []
 # clock/duration are TriCera keywords; reported when the token appears
 clockTokenSeen: false
 durationTokenSeen: false
+# C++ names introduced by template instantiation, and what they stand for
+mangledNames: []

--- a/tests/facts/Answers
+++ b/tests/facts/Answers
@@ -1,0 +1,128 @@
+
+malloc_use.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: [free, malloc]
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+nothing_referenced.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+malloc_in_removed_decl.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+sized_array.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: true
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+unbounded_array_param.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: true
+usesUnboundedArrays: true
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+determinize_adds_arrays.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: [IN1_g]
+inputArrays: [IN_ARR_2_g]
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+determinize_with_own_arrays.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: true
+usesUnboundedArrays: true
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: [IN1_g]
+inputArrays: [IN_ARR_2_g]
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: false
+durationTokenSeen: false
+
+time_tokens.c
+exit code: 0
+---
+# facts about the produced program; a missing fact means "not determined"
+# allocation functions the program references
+allocationFunctions: []
+# declarations with array types / with arrays of unknown bound
+usesArrays: false
+usesUnboundedArrays: false
+# inputs added by the determinizer (also in the INPUT header comment)
+inputVariables: []
+inputArrays: []
+# approximate: token-level scan for TriCera's clock/duration extensions
+clockTokenSeen: true
+durationTokenSeen: false

--- a/tests/facts/determinize_adds_arrays.c
+++ b/tests/facts/determinize_adds_arrays.c
@@ -1,0 +1,13 @@
+/* --determinize replaces the nondet calls with an input variable and an
+   unbounded input array; these are reported as inputs, separately from
+   the program's own (here: none) array declarations. */
+extern int nondet_int(void);
+int main() {
+  int n = nondet_int();
+  int acc = 0;
+  while (n > 0) {
+    acc += nondet_int();
+    n--;
+  }
+  return acc;
+}

--- a/tests/facts/determinize_with_own_arrays.c
+++ b/tests/facts/determinize_with_own_arrays.c
@@ -1,0 +1,14 @@
+/* the program declares its own arrays (one of unknown bound) and also
+   gets determinizer inputs: the facts keep the two apart. */
+extern int nondet_int(void);
+int own_unbounded[];
+int main() {
+  int own_sized[2] = {0, 1};
+  int n = nondet_int();
+  int acc = own_sized[0] + own_unbounded[0];
+  while (n > 0) {
+    acc += nondet_int();
+    n--;
+  }
+  return acc;
+}

--- a/tests/facts/exceptions.cpp
+++ b/tests/facts/exceptions.cpp
@@ -1,0 +1,14 @@
+/* throw and try/catch are reported, TriCera transforms exceptions away. */
+int risky(int v) {
+  if (v < 0)
+    throw 42;
+  return v + 1;
+}
+
+int main() {
+  try {
+    return risky(1);
+  } catch (int e) {
+    return e;
+  }
+}

--- a/tests/facts/malloc_in_removed_decl.c
+++ b/tests/facts/malloc_in_removed_decl.c
@@ -1,0 +1,9 @@
+/* the only malloc sits in an unused function that tri-pp removes;
+   the produced program references no allocation function. */
+extern void *malloc(unsigned long);
+void unused_heap_user(void) {
+  int *p = malloc(4);
+}
+int main() {
+  return 0;
+}

--- a/tests/facts/malloc_use.c
+++ b/tests/facts/malloc_use.c
@@ -1,0 +1,10 @@
+/* malloc and free referenced in live code. */
+extern void *malloc(unsigned long);
+extern void free(void *);
+int main() {
+  int *p = malloc(sizeof *p);
+  *p = 4;
+  int v = *p;
+  free(p);
+  return v;
+}

--- a/tests/facts/nothing_referenced.c
+++ b/tests/facts/nothing_referenced.c
@@ -1,0 +1,5 @@
+/* no allocation functions, arrays or time tokens. */
+int add(int a, int b) { return a + b; }
+int main() {
+  return add(20, 22);
+}

--- a/tests/facts/runtests
+++ b/tests/facts/runtests
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Facts sidecar: --facts <path> writes a small YAML file stating facts
+# about the produced program (referenced allocation functions, array
+# declarations, clock/duration tokens); what to do with them is TriCera's
+# decision. The program output itself goes to /dev/null; only the facts
+# files are compared.
+
+run() {
+    name=$1; shift
+    echo
+    echo "$name"
+    $TRI_CMD "$@" --facts Output.facts.yml "$name" -o /dev/null -- -xc 2>&1
+    echo "exit code: $?"
+    cat Output.facts.yml
+    rm -f Output.facts.yml
+}
+
+run malloc_use.c "$@"
+run nothing_referenced.c "$@"
+run malloc_in_removed_decl.c "$@"
+run sized_array.c "$@"
+run unbounded_array_param.c "$@"
+run determinize_adds_arrays.c "$@" --determinize
+run determinize_with_own_arrays.c "$@" --determinize
+run time_tokens.c "$@"

--- a/tests/facts/runtests
+++ b/tests/facts/runtests
@@ -10,7 +10,10 @@ run() {
     name=$1; shift
     echo
     echo "$name"
-    $TRI_CMD "$@" --facts Output.facts.yml "$name" -o /dev/null -- -xc 2>&1
+    case "$name" in
+        *.cpp) $TRI_CMD "$@" --facts Output.facts.yml "$name" -o /dev/null -- 2>&1 ;;
+        *)     $TRI_CMD "$@" --facts Output.facts.yml "$name" -o /dev/null -- -xc 2>&1 ;;
+    esac
     echo "exit code: $?"
     cat Output.facts.yml
     rm -f Output.facts.yml
@@ -24,3 +27,4 @@ run unbounded_array_param.c "$@"
 run determinize_adds_arrays.c "$@" --determinize
 run determinize_with_own_arrays.c "$@" --determinize
 run time_tokens.c "$@"
+run exceptions.cpp "$@"

--- a/tests/facts/sized_array.c
+++ b/tests/facts/sized_array.c
@@ -1,0 +1,5 @@
+/* a sized array declaration: usesArrays without usesUnboundedArrays. */
+int main() {
+  int xs[3] = {1, 2, 3};
+  return xs[0] + xs[1] + xs[2];
+}

--- a/tests/facts/time_tokens.c
+++ b/tests/facts/time_tokens.c
@@ -1,0 +1,6 @@
+/* the token-level scan is approximate by design: any clock/duration
+   identifier is reported, here a plain variable name. */
+int main() {
+  int clock = 3;
+  return clock;
+}

--- a/tests/facts/unbounded_array_param.c
+++ b/tests/facts/unbounded_array_param.c
@@ -1,0 +1,11 @@
+/* an array parameter of unknown bound. */
+int sum(int a[], int n) {
+  int s = 0;
+  int i;
+  for (i = 0; i < n; i++) s += a[i];
+  return s;
+}
+int main() {
+  int xs[3] = {1, 2, 3};
+  return sum(xs, 3);
+}

--- a/tests/line_markers/Answers
+++ b/tests/line_markers/Answers
@@ -1,0 +1,57 @@
+
+geometry_preserving.c
+tri-pp exit code: 0
+PASS: no markers for line-count-preserving input
+PASS: probe_a -> geometry_preserving.c:15, geometry_preserving.c:18
+PASS: probe_b -> geometry_preserving.c:16, geometry_preserving.c:18, geometry_preserving.c:20
+PASS: probe_c -> geometry_preserving.c:20, geometry_preserving.c:21
+checker exit code: 0
+parse-equivalence: PASS
+
+clone_functions.c
+tri-pp exit code: 0
+PASS: probe_helper_body -> clone_functions.c:6, clone_functions.c:7
+PASS: probe_main -> clone_functions.c:13, clone_functions.c:14
+checker exit code: 0
+parse-equivalence: PASS
+
+determinize_top.c
+tri-pp exit code: 0
+PASS: probe_acc -> determinize_top.c:7, determinize_top.c:9, determinize_top.c:12
+PASS: probe_x -> determinize_top.c:6, determinize_top.c:8, determinize_top.c:10
+checker exit code: 0
+parse-equivalence: PASS
+
+multiline_for.c
+tri-pp exit code: 0
+PASS: probe_acc -> multiline_for.c:7, multiline_for.c:11, multiline_for.c:13
+PASS: probe_after -> multiline_for.c:13, multiline_for.c:14
+PASS: probe_i -> multiline_for.c:8, multiline_for.c:10, multiline_for.c:11
+PASS: probe_n -> multiline_for.c:6, multiline_for.c:10
+checker exit code: 0
+parse-equivalence: PASS
+
+chained_markers.c
+tri-pp exit code: 0
+PASS: probe_a -> original.c:200, original.c:300
+PASS: probe_b -> original.c:300, original.c:301
+PASS: probe_v -> original.c:102, original.c:103
+checker exit code: 0
+parse-equivalence: PASS
+
+acsl_annotations.c
+tri-pp exit code: 0
+PASS: probe_h -> acsl_annotations.c:8, acsl_annotations.c:9
+PASS: probe_m -> acsl_annotations.c:22, acsl_annotations.c:23
+PASS: probe_v -> acsl_annotations.c:12, acsl_annotations.c:13, acsl_annotations.c:15, acsl_annotations.c:16
+checker exit code: 0
+ACSL byte-identical: PASS
+no marker inside ACSL: PASS
+
+chained stages (determinize_top.c)
+tri-pp exit code: 0
+tri-pp exit code: 0
+tri-pp exit code: 0
+PASS: probe_acc -> determinize_top.c:7, determinize_top.c:9, determinize_top.c:12
+PASS: probe_x -> determinize_top.c:6, determinize_top.c:8, determinize_top.c:10
+checker exit code: 0

--- a/tests/line_markers/Answers
+++ b/tests/line_markers/Answers
@@ -55,3 +55,10 @@ tri-pp exit code: 0
 PASS: probe_acc -> determinize_top.c:7, determinize_top.c:9, determinize_top.c:12
 PASS: probe_x -> determinize_top.c:6, determinize_top.c:8, determinize_top.c:10
 checker exit code: 0
+
+cxx_templates.cpp
+tri-pp exit code: 0
+PASS: probe_a -> cxx_templates.cpp:22, cxx_templates.cpp:23, cxx_templates.cpp:24
+PASS: probe_arg -> cxx_templates.cpp:16, cxx_templates.cpp:17
+PASS: probe_b -> cxx_templates.cpp:23, cxx_templates.cpp:24
+checker exit code: 0

--- a/tests/line_markers/acsl_annotations.c
+++ b/tests/line_markers/acsl_annotations.c
@@ -1,0 +1,24 @@
+/* ACSL annotations must pass through byte-identical, 
+   no marker may be placed inside one, and
+   probes inside them must keep mapping to their original lines. The clone
+   of helper is inserted right before the contract of `annotated`. */
+extern int nondet_int(void);
+
+int helper(int a) {
+  int probe_h = nondet_int();
+  return a + probe_h;
+}
+
+/*@ requires probe_v > 0;
+  @ ensures \result == probe_v + 1;
+  @*/
+int annotated(int probe_v) {
+  return probe_v + 1;
+}
+
+int main() {
+  int x = helper(1);
+  int y = helper(2);
+  int probe_m = annotated(x + y);
+  return probe_m;
+}

--- a/tests/line_markers/chained_markers.c
+++ b/tests/line_markers/chained_markers.c
@@ -1,0 +1,14 @@
+# 100 "original.c"
+typedef int myint;
+
+int compute(int probe_v) {
+  return probe_v + 1;
+}
+
+int main() {
+# 200 "original.c"
+  myint probe_a = compute(1);
+#line 300 "original.c"
+  int probe_b = compute(probe_a);
+  return probe_b;
+}

--- a/tests/line_markers/check_markers.py
+++ b/tests/line_markers/check_markers.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Verifies tri-pp --line-markers output against its input.
+
+Mirrors the TriCera-side consumer: every line matching
+^#\\s*[0-9]+\\s+"[^"]*".*$ is recorded into a segment map (the next line is
+line N of file F, following lines count up from there) and dropped; lines
+before the first marker map to themselves. The same map is built for the
+input, so inputs that already carry markers (cpp output, earlier tri-pp
+stage) are handled identically.
+
+Every identifier containing "probe_" must map to the same (file, line) set
+in input and output -- i.e. every probe occurrence in the output, including
+ones in copied text such as function clones, maps back to the authentic
+original line of that probe.
+
+usage: check_markers.py <input.c> <output.c> [--expect-zero-markers]
+                        [--alias=<name>]
+--alias names the work file of a chained tri-pp run: markers naming it
+refer to the original input and are compared as such.
+prints PASS or FAIL lines; exits non-zero on FAIL.
+"""
+import re
+import sys
+
+MARKER = re.compile(r'^#\s*([0-9]+)\s+"([^"]*)"')
+# the input may also carry #line directives (clang consumes both forms);
+# tri-pp itself must only ever emit the GNU linemarker form
+LINE_DIRECTIVE = re.compile(r'^#\s*line\s+([0-9]+)\s+"([^"]*)"')
+PROBE = re.compile(r'\bprobe_[A-Za-z0-9_]*')
+
+
+def consumer_map(lines, default_file, with_line_directives=False):
+    """(file, line) for each physical line; None for marker lines."""
+    mapping = []
+    cur_file, cur_line = None, 0
+    for ln in lines:
+        m = MARKER.match(ln)
+        if m is None and with_line_directives:
+            m = LINE_DIRECTIVE.match(ln)
+        if m:
+            mapping.append(None)
+            cur_file, cur_line = m.group(2), int(m.group(1))
+            continue
+        if cur_file is None:
+            mapping.append((default_file, len(mapping) + 1))
+        else:
+            mapping.append((cur_file, cur_line))
+            cur_line += 1
+    return mapping
+
+
+def probe_locations(lines, mapping, alias=None, alias_to=None):
+    """probe name -> set of mapped (file, line) of its occurrences.
+
+    File names are compared by base name: the tool absolutizes the input
+    path, so markers carry absolute paths while the input is named as
+    invoked. A file named like `alias` is reported as `alias_to`."""
+    locs = {}
+    for i, ln in enumerate(lines):
+        if mapping[i] is None:
+            continue
+        f, l = mapping[i]
+        base = f.split('/')[-1]
+        if alias is not None and base == alias:
+            base = alias_to
+        for m in PROBE.finditer(ln):
+            locs.setdefault(m.group(0), set()).add((base, l))
+    return locs
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    expect_zero = '--expect-zero-markers' in sys.argv
+    alias = None
+    for a in sys.argv[1:]:
+        if a.startswith('--alias='):
+            alias = a.split('=', 1)[1]
+    input_path, output_path = args
+    with open(input_path) as f:
+        in_lines = f.read().split('\n')
+    with open(output_path) as f:
+        out_lines = f.read().split('\n')
+
+    failures = 0
+
+    n_markers = sum(1 for ln in out_lines if MARKER.match(ln))
+    if expect_zero:
+        if n_markers == 0:
+            print("PASS: no markers for line-count-preserving input")
+        else:
+            print("FAIL: expected zero markers, found %d" % n_markers)
+            failures += 1
+
+    # the input maps through its own markers; the file the consumer reads is
+    # named like the input here, so identity regions agree between the two
+    in_map = consumer_map(in_lines, input_path, with_line_directives=True)
+    out_map = consumer_map(out_lines, input_path)
+
+    for i, ln in enumerate(out_lines):
+        if LINE_DIRECTIVE.match(ln):
+            print("FAIL: output line %d is a #line directive; only GNU"
+                  " linemarkers may be emitted" % (i + 1))
+            failures += 1
+    in_base = input_path.split('/')[-1]
+    in_probes = probe_locations(in_lines, in_map)
+    out_probes = probe_locations(out_lines, out_map, alias, in_base)
+
+    if not in_probes:
+        print("FAIL: input contains no probe_ tokens")
+        failures += 1
+
+    for name in sorted(in_probes):
+        want = in_probes[name]
+        got = out_probes.get(name, set())
+        if got == want:
+            where = ", ".join("%s:%d" % (f.split('/')[-1], l)
+                              for f, l in sorted(want))
+            print("PASS: %s -> %s" % (name, where))
+        else:
+            print("FAIL: %s mapped to %s, expected %s" %
+                  (name, sorted(got), sorted(want)))
+            failures += 1
+
+    for name in sorted(set(out_probes) - set(in_probes)):
+        print("FAIL: probe %s appears only in the output" % name)
+        failures += 1
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/line_markers/clone_functions.c
+++ b/tests/line_markers/clone_functions.c
@@ -1,0 +1,15 @@
+/* --make-calls-unique clones `helper` for its second call site; the
+   cloned body must map back to helper's original lines. */
+extern int nondet_int(void);
+
+int helper(int a) {
+  int probe_helper_body = nondet_int();
+  return a + probe_helper_body;
+}
+
+int main() {
+  int x = helper(1);
+  int y = helper(2);
+  int probe_main = x + y;
+  return probe_main;
+}

--- a/tests/line_markers/cxx_templates.cpp
+++ b/tests/line_markers/cxx_templates.cpp
@@ -1,0 +1,25 @@
+// The class template is monomorphised and its instantiation injected,
+// which shifts the lines after it. The markers must re-sync so the probed
+// variables in the non-template code below still map to their original
+// lines. (Names inside the template body are reprinted into the
+// instantiation and map only approximately, by contract, so none are put
+// there.)
+template <typename T>
+class Box {
+public:
+  Box(T v) : value(v) {}
+  T get() const { return value; }
+private:
+  T value;
+};
+
+int helper(int probe_arg) {
+  return probe_arg + 1;
+}
+
+int main() {
+  Box<int> b(7);
+  int probe_a = b.get();
+  int probe_b = helper(probe_a);
+  return probe_a + probe_b;
+}

--- a/tests/line_markers/determinize_top.c
+++ b/tests/line_markers/determinize_top.c
@@ -1,0 +1,13 @@
+/* --determinize inserts global input declarations at the top of the
+   file; every original line must still map to itself. */
+extern int nondet_int(void);
+
+int main() {
+  int probe_x = nondet_int();
+  int probe_acc = 0;
+  while (probe_x > 0) {
+    probe_acc += nondet_int();
+    probe_x--;
+  }
+  return probe_acc;
+}

--- a/tests/line_markers/geometry_preserving.c
+++ b/tests/line_markers/geometry_preserving.c
@@ -1,0 +1,22 @@
+/* All default-pipeline rewrites on this input are geometry-preserving
+   (blanked typedefs and unused decls, canonised types, char literals,
+   loop guard rewriting): the output must contain zero linemarkers. */
+extern int nondet_int(void);
+
+typedef int myint;
+typedef unsigned long ulong_t;
+
+struct unused_struct { int x; };
+enum unused_enum { U_A, U_B };
+
+void unused_fun(void) { }
+
+int main() {
+  myint probe_a = 'a';
+  ulong_t probe_b = 0;
+  while (nondet_int()) {
+    probe_b += probe_a;
+  }
+  int probe_c = (int) probe_b + '\n';
+  return probe_c;
+}

--- a/tests/line_markers/multiline_for.c
+++ b/tests/line_markers/multiline_for.c
@@ -1,0 +1,15 @@
+/* The for-loop declaration spans two lines; extracting it in front of
+   the loop inserts a newline, so markers must re-sync the lines after
+   it. (The decl's own continuation line merges into the for's line;
+   lines are the unit of fidelity, so no probe sits there.) */
+int main() {
+  int probe_n = 5;
+  int probe_acc = 0;
+  for (int probe_i = 0,
+       j = 1;
+       probe_i < probe_n; probe_i++) {
+    probe_acc += probe_i * j;
+  }
+  int probe_after = probe_acc;
+  return probe_after;
+}

--- a/tests/line_markers/runtests
+++ b/tests/line_markers/runtests
@@ -68,3 +68,15 @@ done
 python3 check_markers.py determinize_top.c Output.chain.c --alias=Output.chain.c
 echo "checker exit code: $?"
 rm -f Output.chain.c Output.chain.step
+
+# A C++ template file: the instantiation injected by the C++ round shifts
+# the lines after it; the probe_ names in the non-template code must still
+# map to their original lines. (-xc++; template-interior names map only
+# approximately, by contract, so none are placed there.)
+echo
+echo cxx_templates.cpp
+$TRI_CMD "$@" --line-markers cxx_templates.cpp -o Output.cxx.cpp -- -xc++ 2>&1
+echo "tri-pp exit code: $?"
+python3 check_markers.py cxx_templates.cpp Output.cxx.cpp
+echo "checker exit code: $?"
+rm -f Output.cxx.cpp

--- a/tests/line_markers/runtests
+++ b/tests/line_markers/runtests
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# Verification harness for --line-markers (see check_markers.py):
+#  - every probe_ token in the output maps back to its authentic original
+#    line through the emitted markers (the map is built exactly like the
+#    TriCera-side consumer builds it);
+#  - line-count-preserving inputs produce zero markers;
+#  - stripping marker lines (blank-padding them) leaves a file gcc can
+#    still parse.
+
+check() {
+    name=$1; shift
+    expect=$1; shift
+    echo
+    echo "$name"
+    $TRI_CMD "$@" "$name" -o "Output.$name" -- -xc 2>&1
+    echo "tri-pp exit code: $?"
+    python3 check_markers.py "$name" "Output.$name" $expect
+    echo "checker exit code: $?"
+    sed 's/^#[ \t]*[0-9].*$//' "Output.$name" > "Output.$name.stripped"
+    if gcc -fsyntax-only -x c "Output.$name.stripped" 2>/dev/null; then
+        echo "parse-equivalence: PASS"
+    else
+        echo "parse-equivalence: FAIL"
+    fi
+    rm -f "Output.$name" "Output.$name.stripped"
+}
+
+check geometry_preserving.c --expect-zero-markers "$@" --line-markers
+check clone_functions.c     ""                    "$@" --line-markers --make-calls-unique
+check determinize_top.c     ""                    "$@" --line-markers --determinize
+check multiline_for.c       ""                    "$@" --line-markers
+check chained_markers.c     ""                    "$@" --line-markers
+
+# ACSL annotations must pass through byte-identical, with no marker line
+# inside a multi-line annotation, and text inside them must keep mapping to
+# the original lines.
+echo
+echo acsl_annotations.c
+$TRI_CMD "$@" --line-markers --make-calls-unique acsl_annotations.c -o Output.acsl.c -- -xc 2>&1
+echo "tri-pp exit code: $?"
+python3 check_markers.py acsl_annotations.c Output.acsl.c
+echo "checker exit code: $?"
+awk '/\/\*@/,/@\*\//' acsl_annotations.c > Output.acsl.expected
+if [ "$(grep -Fx -c -f Output.acsl.expected Output.acsl.c)" = "$(wc -l < Output.acsl.expected)" ]; then
+    echo "ACSL byte-identical: PASS"
+else
+    echo "ACSL byte-identical: FAIL"
+fi
+if awk '/\/\*@/{inb=1} inb && /^#/{found=1} /@\*\//{inb=0} END{exit !found}' Output.acsl.c; then
+    echo "no marker inside ACSL: FAIL"
+else
+    echo "no marker inside ACSL: PASS"
+fi
+rm -f Output.acsl.c Output.acsl.expected
+
+# TriCera invokes tri-pp up to three times in a row for --determinize, each
+# stage reading the previous stage's output from the same path; the markers
+# must keep mapping every line to the first stage's input.
+echo
+echo "chained stages (determinize_top.c)"
+cp determinize_top.c Output.chain.c
+for flags in "" "--make-calls-unique" "--determinize"; do
+    $TRI_CMD "$@" --line-markers $flags Output.chain.c -o Output.chain.step -- -xc 2>&1
+    echo "tri-pp exit code: $?"
+    mv Output.chain.step Output.chain.c
+done
+python3 check_markers.py determinize_top.c Output.chain.c --alias=Output.chain.c
+echo "checker exit code: $?"
+rm -f Output.chain.c Output.chain.step

--- a/tests/program_transformations/Answers
+++ b/tests/program_transformations/Answers
@@ -84,7 +84,23 @@ void main()
 loop_rewrite.c
 extern int nondet_int();
 void main() {
-  { int __loop_idx_0 = nondet_int(); while(__loop_idx_0-->0) {
+  { int __loop_idx_0 = nondet_int(); while(__loop_idx_0-->0            ) {
     int x = 1;
   } }
 }
+
+entry_function.c
+/* with -m foo, slicing is relative to foo: helper stays, main and the
+   unused struct are removed. */
+int helper(int x) { return x + 1; }
+                           
+int foo(void) { return helper(41); }
+                        
+
+no_decl_slice.c
+/* with --no-decl-slice nothing is sliced away; typedefs are still
+   removed (that is not slicing), so their uses must still be canonised. */
+                     
+struct unused_s { int f; };
+void unused_fun(void) { }
+int main() { return 0; }

--- a/tests/program_transformations/entry_function.c
+++ b/tests/program_transformations/entry_function.c
@@ -1,0 +1,6 @@
+/* with -m foo, slicing is relative to foo: helper stays, main and the
+   unused struct are removed. */
+int helper(int x) { return x + 1; }
+struct unused_s { int f; };
+int foo(void) { return helper(41); }
+int main() { return 0; }

--- a/tests/program_transformations/no_decl_slice.c
+++ b/tests/program_transformations/no_decl_slice.c
@@ -1,0 +1,6 @@
+/* with --no-decl-slice nothing is sliced away; typedefs are still
+   removed (that is not slicing), so their uses must still be canonised. */
+typedef int unused_t;
+struct unused_s { int f; };
+void unused_fun(void) { }
+int main() { return 0; }

--- a/tests/program_transformations/runtests
+++ b/tests/program_transformations/runtests
@@ -2,7 +2,9 @@
 
 TESTS="determinize.c \
        make_calls_unique.c \
-       loop_rewrite.c"
+       loop_rewrite.c \
+       entry_function.c \
+       no_decl_slice.c"
 
 for name in $TESTS; do
     echo
@@ -11,5 +13,7 @@ for name in $TESTS; do
         determinize.c) $TRI_CMD "$@" --determinize determinize.c -- -xc 2>&1 ;;
         make_calls_unique.c) $TRI_CMD "$@" --make-calls-unique make_calls_unique.c -- -xc 2>&1 ;;
         loop_rewrite.c) $TRI_CMD "$@" loop_rewrite.c -- -xc 2>&1 ;;
+        entry_function.c) $TRI_CMD "$@" -m foo entry_function.c -- -xc 2>&1 ;;
+        no_decl_slice.c) $TRI_CMD "$@" --no-decl-slice no_decl_slice.c -- -xc 2>&1 ;;
     esac
 done

--- a/tests/rewrite_conflicts/Answers
+++ b/tests/rewrite_conflicts/Answers
@@ -1,0 +1,36 @@
+
+guard_copy_canonised.c
+/* NondetLoopGuardRewriter copies the guard into the counter
+   initialisation and blanks the original; a later round canonises the
+   sizeof inside the copy like any other code. */
+extern int nondet(int);
+
+int main() {
+  int *p;
+  int n = 0;
+  { int __loop_idx_0 = nondet(sizeof(int)); while (__loop_idx_0-->0                 ) {
+    n++;
+  } }
+  return n;
+}
+exit code: 0
+
+conflict_nested_nondet.c
+[tricera-preprocessor] error: 1 conflicting rewrite pair(s) detected, output not written
+conflict 1:
+  [Determinizer] replacement at line 9:11 (offsets 342-362): "IN1_g"
+  [Determinizer] replacement at line 9:20 (offsets 351-361): "IN2_g"
+exit code: 4
+
+clean_no_conflict.c
+/* Same shape without the nested rewrite: no conflict, output written. */
+extern int nondet(void);
+
+int main() {
+  int n = 0;
+  { int __loop_idx_0 = nondet(); while (__loop_idx_0-->0        ) {
+    n++;
+  } }
+  return n;
+}
+exit code: 0

--- a/tests/rewrite_conflicts/clean_no_conflict.c
+++ b/tests/rewrite_conflicts/clean_no_conflict.c
@@ -1,0 +1,10 @@
+/* Same shape without the nested rewrite: no conflict, output written. */
+extern int nondet(void);
+
+int main() {
+  int n = 0;
+  while (nondet()) {
+    n++;
+  }
+  return n;
+}

--- a/tests/rewrite_conflicts/conflict_nested_nondet.c
+++ b/tests/rewrite_conflicts/conflict_nested_nondet.c
@@ -1,0 +1,11 @@
+/* Under --determinize both calls are rewritten, and the replacement of
+   the outer call overlaps the replacement of its nested argument: the
+   composed text depends on transformer order. tri-pp must refuse
+   (exit code 4) instead of producing silent garbage */
+extern int nondet_a(void);
+extern int nondet_b(int);
+
+int main() {
+  int x = nondet_b(nondet_a());
+  return x;
+}

--- a/tests/rewrite_conflicts/guard_copy_canonised.c
+++ b/tests/rewrite_conflicts/guard_copy_canonised.c
@@ -1,0 +1,13 @@
+/* NondetLoopGuardRewriter copies the guard into the counter
+   initialisation and blanks the original; a later round canonises the
+   sizeof inside the copy like any other code. */
+extern int nondet(int);
+
+int main() {
+  int *p;
+  int n = 0;
+  while (nondet(sizeof *p)) {
+    n++;
+  }
+  return n;
+}

--- a/tests/rewrite_conflicts/runtests
+++ b/tests/rewrite_conflicts/runtests
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Rewrite-conflict detection: order-dependent transformer edits must be
+# reported with both offending edits and a non-zero exit, and must produce
+# no output; order-independent compositions must keep working. The
+# conflict case deliberately drops "$@" (i.e. -q) so the diagnostic itself
+# is part of the compared output.
+
+echo
+echo guard_copy_canonised.c
+$TRI_CMD "$@" guard_copy_canonised.c -- -xc 2>&1
+echo "exit code: $?"
+
+echo
+echo conflict_nested_nondet.c
+$TRI_CMD --determinize conflict_nested_nondet.c -- -xc 2>&1
+echo "exit code: $?"
+
+echo
+echo clean_no_conflict.c
+$TRI_CMD "$@" clean_no_conflict.c -- -xc 2>&1
+echo "exit code: $?"

--- a/tests/runalldirs
+++ b/tests/runalldirs
@@ -24,6 +24,7 @@ run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/program_transformations" "" "-q"
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/rewrite_conflicts" "" "-q"
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/line_markers" "" "-q"
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/facts" "" "-q"
+run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/cpp_support" "" "-q"
 
 if [ $ERRORS -ne 0 ]; then
     exit 1

--- a/tests/runalldirs
+++ b/tests/runalldirs
@@ -21,6 +21,9 @@ run_test() {
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/unused_decl_commenter" "" "-q"
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/typedef_remover" "" "-q"
 run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/program_transformations" "" "-q"
+run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/rewrite_conflicts" "" "-q"
+run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/line_markers" "" "-q"
+run_test "$SCRIPT_DIR/rundir" "$SCRIPT_DIR/facts" "" "-q"
 
 if [ $ERRORS -ne 0 ]; then
     exit 1

--- a/tests/typedef_remover/Answers
+++ b/tests/typedef_remover/Answers
@@ -1,15 +1,15 @@
 
 typedef_removal.c
-/* typedef  */ struct T { int x; }/*  T */ ;
+        struct T { int x; }  ;
 struct T global;
 void main() { global.x = 1; }
 
 struct_multi_field.c
-/* typedef  */ struct Point3D {
+        struct Point3D {
     int x;
     int y;
     double z;
-}/*  Point3D */ ;
+}        ;
 
 void main() {
     struct Point3D p;
@@ -17,24 +17,24 @@ void main() {
 }
 
 struct_single_line.c
-/* typedef  */ struct Point2D { int x; int y; }/*  Point2D */ ;
+        struct Point2D { int x; int y; }        ;
 void main() { struct Point2D p; p.x = 1; }
 
 struct_combined_fields.c
-/* typedef  */ struct Vector {
+        struct Vector {
     int x, y, z;
-}/*  Vector */ ;
+}       ;
 void main() { struct Vector v; v.x = 0; }
 
 nested_struct.c
-/* typedef  */ struct Inner {
+        struct Inner {
     int x;
-}/*  Inner */ ;
+}      ;
 
-/* typedef  */ struct Outer {
+        struct Outer {
     struct Inner i;
     int y;
-}/*  Outer */ ;
+}      ;
 
 void main() {
     struct Outer o;
@@ -42,9 +42,9 @@ void main() {
 }
 
 struct_array.c
-/* typedef  */ struct Buffer {
+        struct Buffer {
     int data[10];
-}/*  Buffer */ ;
+}       ;
 
 void main() {
     struct Buffer b;
@@ -52,10 +52,10 @@ void main() {
 }
 
 struct_pointer.c
-/* typedef  */ struct Node {
+        struct Node {
     struct Node *next;
     int val;
-}/*  Node */ ;
+}     ;
 
 void main() {
     struct Node n;
@@ -63,17 +63,17 @@ void main() {
 }
 
 enum_typedef.c
-/* typedef  */ enum Color {
+        enum Color {
     RED, GREEN, BLUE
-}/*  Color */ ;
+}      ;
 
 void main() {
     enum Color c = RED;
 }
 
 basic_type_alias.c
-// typedef int MyInt;
-// typedef unsigned long MyUlong;
+                  
+                              
 
 void main() {
     int i = 10;
@@ -82,7 +82,7 @@ void main() {
 
 multi_typedef.c
 struct S { int x; };
-// typedef struct S T1, *T2;
+                         
 
 void main() {
     struct S a;
@@ -90,10 +90,10 @@ void main() {
 }
 
 anonymous_struct_typedef.c
-// // typedef struct {
-// //     int a;
-// // } Anon;
+                
+          
+       
 
 void main() {
-//     Anon x;
+           
 }

--- a/tests/unused_decl_commenter/Answers
+++ b/tests/unused_decl_commenter/Answers
@@ -1,10 +1,10 @@
 
 enum_array_size.c
-/* typedef  */ enum MyEnum {
+        enum MyEnum {
     FIRST,
     SECOND,
     MyEnum_COUNT
-}/*  MyEnum */ ;
+}       ;
 
 int array[MyEnum_COUNT];
 
@@ -13,11 +13,11 @@ void main(void) {
 }
 
 enum_in_expr.c
-/* typedef  */ enum E { A, B }/*  E */ ;
+        enum E { A, B }  ;
 void main() { int x = A + 1; }
 
 assert_macro.c
-/* typedef  */ enum E { ONE }/*  E */ ;
+        enum E { ONE }  ;
 #define assert(x) if(!(x)) {}
 void main() { assert(ONE); }
 
@@ -26,9 +26,9 @@ struct Unused { int x; };
 void main() {}
 
 unused_struct.c
-// struct Unused {
-//     int x;
-// };
+               
+          
+  
 
 void main() {
 }
@@ -44,8 +44,8 @@ void main() {
 }
 
 unused_func.c
-// void unused() {
-// }
+               
+ 
 
 void main() {
 }
@@ -59,9 +59,9 @@ void main() {
 }
 
 unused_enum.c
-// enum Unused {
-//     A, B
-// };
+             
+        
+  
 
 void main() {
 }
@@ -94,7 +94,7 @@ void f() {
 }
 
 func_decl_unused.c
-// void f();
+         
 void main() {}
 
 struct_forward_decl.c
@@ -108,12 +108,12 @@ void f(enum E e) {}
 void main() { f(A); }
 
 typedef_struct_usage.c
-/* typedef  */ struct T { int x; }/*  T */ ;
+        struct T { int x; }  ;
 void f(struct T t) {}
 void main() { struct T t; f(t); }
 
 typedef_struct_unused.c
-// // typedef struct { int x; } T;
+                            
 void main() { int x = 1; }
 
 array_of_structs.c
@@ -122,7 +122,7 @@ struct S arr[10];
 void main() { arr[0].x = 1; }
 
 array_of_structs_unused.c
-// struct S { int x; };
+                    
 int arr[10];
 void main() { arr[0] = 1; }
 
@@ -132,7 +132,7 @@ void f(struct S* p) { p->x = 1; }
 void main() { struct S s; f(&s); }
 
 pointer_to_struct_unused.c
-// struct S { int x; };
+                    
 void f(int* p) { *p = 1; }
 void main() { int s; f(&s); }
 
@@ -142,7 +142,7 @@ struct B { struct A a; };
 void main() { struct B b; b.a.x = 1; }
 
 struct_in_struct_unused.c
-// struct A { int x; };
+                    
 struct B { int y; };
 void main() { struct B b; b.y = 1; }
 
@@ -152,7 +152,7 @@ struct S { enum E e; };
 void main() { struct S s; s.e = A; }
 
 enum_in_struct_unused.c
-// enum E { A };
+             
 struct S { int e; };
 void main() { struct S s; s.e = 1; }
 
@@ -162,7 +162,7 @@ struct S f() { struct S s; return s; }
 void main() { f(); }
 
 return_struct_unused.c
-// struct S { int a; };
+                    
 int f() { return 0; }
 void main() { f(); }
 
@@ -172,11 +172,11 @@ void f(struct S s) {}
 void main() { struct S s; f(s); }
 
 param_struct_unused.c
-// struct S { int a; };
+                    
 void f(int s) {}
 void main() { f(1); }
 
 func_decl_impl_unused.c
-// void f();
+         
 void main() {}
-// void f() {}
+           


### PR DESCRIPTION
- Transformers now run in rounds, one transformer per round, each on a fresh parse of the previous round's in-memory text. Edits of two transformers can no longer interfere; order-dependent edits within one transformer are reported with both offending edits and exit code 4 instead of silently producing garbage. A round that rewrites nothing reuses its parse.
- Removed code is blanked with whitespace of identical geometry instead of being commented out. This fixes nested-comment corruption.
- `--line-markers` emits GNU linemarkers mapping every output line back to the input.
- `--facts <path>` writes a YAML sidecar stating some facts about the produced program. For now: referenced allocation functions, array declarations, throw/try-catch, clock/duration tokens, determinizer-added inputs, and the mangled-name map from template instantiation.
- C++ to C+ translator for C++ files. Templates are monomorphised under mangled names, implicit member accesses become explicit, non-virtual member calls are qualified, throw operands get casts.

CLI is backward compatible. Exit code 4 is new (for conflicting rewrites). `-v` now works without positional arguments, and releases include a sha256 alongside the binary.