### PR TITLE
Cpp remove dtor quals

### DIFF
--- a/lib/CXXToCPlusTranslator.cpp
+++ b/lib/CXXToCPlusTranslator.cpp
@@ -432,6 +432,8 @@ bool CXXToCPlusTranslator::VisitCXXMemberCallExpr(CXXMemberCallExpr *CE) {
   // virtual calls are not statically dispatched, do not qualify them
   if (MD->isVirtual()) return true;
 
+  if (isa<CXXDestructorDecl>(MD)) return true; // skip destructor calls
+
   CXXRecordDecl *RD = MD->getParent();
   if (!RD) return true;
 

--- a/tests/cpp_support/Answers
+++ b/tests/cpp_support/Answers
@@ -427,3 +427,23 @@ int main() {
 }
 --- mangledNames ---
 mangledNames: []
+
+--- non_qual_dtor.cpp ---
+class C {
+  public:
+    int x;
+    C(int val) {
+      this->x = val;
+    }
+
+    ~C() { }
+};
+
+
+int main() {
+  class C obj(1);
+  obj.~C();
+  return 0;
+}
+--- mangledNames ---
+mangledNames: []

--- a/tests/cpp_support/non_qual_dtor.cpp
+++ b/tests/cpp_support/non_qual_dtor.cpp
@@ -1,0 +1,16 @@
+class C {
+  public:
+    int x;
+    C(int val) {
+      x = val;
+    }
+
+    ~C() { }
+};
+
+
+int main() {
+  C obj(1);
+  obj.~C();
+  return 0;
+}

--- a/tests/cpp_support/runtests
+++ b/tests/cpp_support/runtests
@@ -15,7 +15,8 @@ TESTS="inheritance_multiple.cpp \
        access_member_vars.cpp \
        throw_test.cpp \
        throw_with_cast.cpp \
-       qualified_function_calls.cpp"
+       qualified_function_calls.cpp \
+       non_qual_dtor.cpp"
 
 for name in $TESTS; do
     echo


### PR DESCRIPTION
Currently, calls to class destructors of the form `obj.~C()` and `obj->~C()` gets qualified as `obj.C::~C()`. This is not needed, since we can already distinguish the name of the class from the identifier after `~`. Hence, we remove these qualifications.